### PR TITLE
Parse command line

### DIFF
--- a/bin/Debug.Sample/Debug.Sample.cpp
+++ b/bin/Debug.Sample/Debug.Sample.cpp
@@ -71,7 +71,7 @@ public:
             }
         }
 
-        if (this->port < 0 || this->port > 65535 || args.empty())
+        if (this->port <= 0 || this->port > 65535 || args.empty())
         {
             this->help = true;
         }
@@ -422,8 +422,8 @@ JsErrorCode EnableDebugging(
     JsDebugProtocolHandler* pProtocolHandler, 
     JsDebugService* pService)
 {
-    JsDebugProtocolHandler protocolHandler;
-    JsDebugService service;
+    JsDebugProtocolHandler protocolHandler = nullptr;
+    JsDebugService service = nullptr;
 
     IfFailRet(JsDebugProtocolHandlerCreate(runtime, &protocolHandler));
     IfFailRet(JsDebugServiceCreate(&service));

--- a/bin/Debug.Sample/Debug.Sample.cpp
+++ b/bin/Debug.Sample/Debug.Sample.cpp
@@ -49,9 +49,10 @@ public:
                 }
                 else if (!arg.compare(L"--port") || !arg.compare(L"-p"))
                 {
-                    if (argc > index + 1)
+                    ++index;
+                    if (argc > index)
                     {                        
-                        this->port = std::stoi(std::wstring(argv[index + 1]));
+                        this->port = std::stoi(std::wstring(argv[index]));
                     }
                 }
             }
@@ -85,11 +86,12 @@ public:
     {
         fwprintf(stderr,
             L"\n"
-            L"Usage: chakrahost <script> [options]\n"
+            L"Usage: Debug.Sample.exe <script> [options]\n"
             L"\n"
             L"Options: \n"
-            L"  --inspect        enable debugging\n"
-            L"  --inspect-brk    enable debugging and break\n"
+            L"      --inspect          Enable debugging\n"
+            L"      --inspect-brk      Enable debugging and break\n"
+            L"  -p, --port <number>    Specify the port number\n"
             L"\n");
     }
 };

--- a/bin/Debug.Sample/Debug.Sample.cpp
+++ b/bin/Debug.Sample/Debug.Sample.cpp
@@ -17,19 +17,19 @@ public:
     int port;
     bool help;
 
-	std::vector<std::wstring> args;
+    std::vector<std::wstring> args;
 
     CommandLineArguments()
-		: breakOnNextLine(false)
-		, enableDebugging(false)
-		, port(9229)
-		, help(false)
+        : breakOnNextLine(false)
+        , enableDebugging(false)
+        , port(9229)
+        , help(false)
     {
     }
 
     void ParseCommandLine(int argc, wchar_t* argv[])
     {
-		bool foundScript = false;
+        bool foundScript = false;
 
         for (int index = 1; index < argc; ++index)
         {
@@ -52,22 +52,22 @@ public:
                     ++index;
                     if (argc > index)
                     {
-						// This will return zero if no number was found.
+                        // This will return zero if no number was found.
                         this->port = std::stoi(std::wstring(argv[index]));
                     }
                 }
-				else
-				{
-					// Handle everything else including `-?` and `--help`
-					this->help = true;
-				}
+                else
+                {
+                    // Handle everything else including `-?` and `--help`
+                    this->help = true;
+                }
             }
             else
             {
-				foundScript = true;
+                foundScript = true;
 
-				// Collect any non-flag arguments
-				args.emplace_back(std::move(arg));
+                // Collect any non-flag arguments
+                args.emplace_back(std::move(arg));
             }
         }
 
@@ -87,7 +87,7 @@ public:
             L"      --inspect          Enable debugging\n"
             L"      --inspect-brk      Enable debugging and break\n"
             L"  -p, --port <number>    Specify the port number\n"
-			L"  -?  --help             Show this help info\n"
+            L"  -?  --help             Show this help info\n"
             L"\n");
     }
 };
@@ -168,11 +168,11 @@ std::wstring LoadScript(const std::wstring& fileName)
 //
 
 JsValueRef CALLBACK Echo(
-	JsValueRef callee, 
-	bool isConstructCall, 
-	JsValueRef* arguments, 
-	unsigned short argumentCount, 
-	void* callbackState)
+    JsValueRef callee, 
+    bool isConstructCall, 
+    JsValueRef* arguments, 
+    unsigned short argumentCount, 
+    void* callbackState)
 {
     for (unsigned int index = 1; index < argumentCount; index++)
     {
@@ -201,11 +201,11 @@ JsValueRef CALLBACK Echo(
 //
 
 JsValueRef CALLBACK RunScript(
-	JsValueRef callee, 
-	bool isConstructCall, 
-	JsValueRef* arguments, 
-	unsigned short argumentCount, 
-	void* callbackState)
+    JsValueRef callee, 
+    bool isConstructCall, 
+    JsValueRef* arguments, 
+    unsigned short argumentCount, 
+    void* callbackState)
 {
     JsValueRef result = JS_INVALID_REFERENCE;
 
@@ -248,10 +248,10 @@ JsValueRef CALLBACK RunScript(
 //
 
 JsErrorCode DefineHostCallback(
-	JsValueRef globalObject, 
-	const wchar_t* callbackName, 
-	JsNativeFunction callback, 
-	void* callbackState)
+    JsValueRef globalObject, 
+    const wchar_t* callbackName, 
+    JsNativeFunction callback, 
+    void* callbackState)
 {
     //
     // Get property ID.
@@ -341,7 +341,7 @@ JsErrorCode CreateHostContext(JsRuntimeHandle runtime, std::vector<std::wstring>
         // Create the argument value.
         //
 
-		std::wstring& str = args[index];
+        std::wstring& str = args[index];
 
         JsValueRef argument;
         IfFailRet(JsPointerToString(str.c_str(), str.length(), &argument));
@@ -416,11 +416,11 @@ JsErrorCode PrintScriptException()
 
 JsErrorCode EnableDebugging(
     JsRuntimeHandle runtime,
-	std::string const& runtimeName,
-	bool breakOnNextLine, 
-	int port, 
-	JsDebugProtocolHandler* pProtocolHandler, 
-	JsDebugService* pService)
+    std::string const& runtimeName,
+    bool breakOnNextLine, 
+    int port, 
+    JsDebugProtocolHandler* pProtocolHandler, 
+    JsDebugService* pService)
 {
     JsDebugProtocolHandler protocolHandler;
     JsDebugService service;
@@ -471,8 +471,8 @@ int _cdecl wmain(int argc, wchar_t* argv[])
         if (arguments.enableDebugging)
         {
             IfFailError(
-				EnableDebugging(runtime, "runtime1", arguments.breakOnNextLine, arguments.port, &protocolHandler, &service),
-				L"failed to enable debugging.");
+                EnableDebugging(runtime, "runtime1", arguments.breakOnNextLine, arguments.port, &protocolHandler, &service),
+                L"failed to enable debugging.");
         }
 
         //
@@ -491,7 +491,7 @@ int _cdecl wmain(int argc, wchar_t* argv[])
         //
         // Load the script from the disk.
         //
-		const std::wstring& scriptName = arguments.args[0];
+        const std::wstring& scriptName = arguments.args[0];
         std::wstring script = LoadScript(scriptName);
         if (script.empty())
         {

--- a/bin/Debug.Sample/stdafx.h
+++ b/bin/Debug.Sample/stdafx.h
@@ -13,6 +13,7 @@
 #include <cstdint>
 #include <iostream>
 #include <string>
+#include <vector>
 
 #include <ChakraCore.h>
 #include <ChakraDebugProtocolHandler.h>

--- a/bin/Debug.Sample/test.js
+++ b/bin/Debug.Sample/test.js
@@ -4,6 +4,10 @@ if (typeof host === "undefined") {
   };
 }
 
+for (const arg of host.arguments) {
+    host.echo(`Found arg: ${arg}`);
+}
+
 function doStuff() {
   let i = 0;
   i += 4584;

--- a/lib/Debug.Service/Service.cpp
+++ b/lib/Debug.Service/Service.cpp
@@ -63,7 +63,8 @@ namespace JsDebug
     {
         try
         {
-            m_server.listen(9229);
+			// TODO: Bind to localhost only
+            m_server.listen(port);
             m_server.start_accept();
         }
         catch (const websocketpp::exception& e)

--- a/lib/Debug.Service/Service.cpp
+++ b/lib/Debug.Service/Service.cpp
@@ -63,7 +63,7 @@ namespace JsDebug
     {
         try
         {
-			// TODO: Bind to localhost only
+            // TODO: Bind to localhost only
             m_server.listen(port);
             m_server.start_accept();
         }


### PR DESCRIPTION
Add command line argument parsing. 

```
Usage: Debug.Sample.exe <script> [options]

Options:
      --inspect          Enable debugging
      --inspect-brk      Enable debugging and break
  -p, --port <number>    Specify the port number
```

