### PR TITLE
Create wrapper classes to ensure proper cleanup

### DIFF
--- a/bin/Debug.Sample/stdafx.h
+++ b/bin/Debug.Sample/stdafx.h
@@ -12,6 +12,7 @@
 
 #include <cstdint>
 #include <iostream>
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -65,3 +66,145 @@
             return hr; \
         } \
     }
+
+class DebugProtocolHandler
+{
+private:
+    JsDebugProtocolHandler m_protocolHandler{ nullptr };
+
+public:
+    DebugProtocolHandler(JsRuntimeHandle runtime)
+    {
+        JsDebugProtocolHandler protocolHandler;
+
+        JsErrorCode result = JsDebugProtocolHandlerCreate(runtime, &protocolHandler);
+
+        if (result != JsNoError)
+        {
+            throw new std::exception("Unable to create debug protocol handler.");
+        }
+
+        m_protocolHandler = protocolHandler;
+    }
+
+    ~DebugProtocolHandler()
+    {
+        Destroy();
+    }
+    
+    JsErrorCode Connect(bool breakOnNextLine, JsDebugProtocolHandlerSendResponseCallback callback, void* callbackState)
+    {
+        JsErrorCode result = JsDebugProtocolHandlerConnect(m_protocolHandler,
+            breakOnNextLine, callback, callbackState);
+
+        return result;
+    }
+
+    JsErrorCode Destroy()
+    {
+        JsErrorCode result = JsNoError;
+
+        if (m_protocolHandler != nullptr)
+        {
+            result = JsDebugProtocolHandlerDestroy(m_protocolHandler);
+
+            if (result == JsNoError)
+            {
+                m_protocolHandler = nullptr;
+            }
+        }
+
+        return result;
+    }
+
+    JsErrorCode Disconnect()
+    {
+        JsErrorCode result = JsDebugProtocolHandlerDisconnect(m_protocolHandler);
+
+        return result;
+    }
+
+    JsDebugProtocolHandler GetHandle()
+    {
+        return m_protocolHandler;
+    }
+
+    JsErrorCode WaitForDebugger()
+    {
+        JsErrorCode result = JsDebugProtocolHandlerWaitForDebugger(m_protocolHandler);
+
+        return result;
+    }
+};
+
+
+class DebugService
+{
+private:
+    JsDebugService m_service{ nullptr };
+
+public:
+    DebugService(JsRuntimeHandle runtime)
+    {
+        JsDebugService service;
+
+        JsErrorCode result = JsDebugServiceCreate(&service);
+
+        if (result != JsNoError)
+        {
+            throw new std::exception("Unable to create debug service.");
+        }
+
+        m_service = service;
+    }
+
+    ~DebugService()
+    {
+        Destroy();
+    }
+
+    JsErrorCode Close()
+    {
+        JsErrorCode result = JsDebugServiceClose(m_service);
+
+        return result;
+    }
+
+    JsErrorCode Destroy()
+    {
+        JsErrorCode result = JsNoError;
+
+        if (m_service != nullptr)
+        {
+            result = JsDebugServiceDestroy(m_service);
+
+            if (result == JsNoError)
+            {
+                m_service = nullptr;
+            }
+        }
+
+        return result;
+    }
+
+    JsErrorCode Listen(uint16_t port)
+    {
+        JsErrorCode result = JsDebugServiceListen(m_service, port);
+
+        return result;
+    }
+
+    JsErrorCode RegisterHandler(std::string const& runtimeName, DebugProtocolHandler& protocolHandler, bool breakOnNextLine)
+    {
+        JsErrorCode result = JsDebugServiceRegisterHandler(m_service, runtimeName.c_str(), protocolHandler.GetHandle(), breakOnNextLine);
+
+        return result;
+    }
+
+    JsErrorCode UnregisterHandler(std::string const& runtimeName)
+    {
+        JsErrorCode result = JsDebugServiceUnregisterHandler(m_service, runtimeName.c_str());
+
+        return result;
+    }
+};

--- a/bin/Debug.Sample/stdafx.h
+++ b/bin/Debug.Sample/stdafx.h
@@ -81,7 +81,7 @@ public:
 
         if (result != JsNoError)
         {
-            throw new std::exception("Unable to create debug protocol handler.");
+            throw std::exception("Unable to create debug protocol handler.");
         }
 
         m_protocolHandler = protocolHandler;


### PR DESCRIPTION
IfFailError() can prevent proper cleanup. I've created wrapper classes DebugProtocolHandler and DebugService which encapsulate the handles and ensure cleanup in destructor.

I could move these to a separate header file. I wanted to get feedback to see what sort of naming should be used. Also, it would be nice to expose these from the lib so it could be used in the host app. As I've started integrating code, I realized that the cleanup and error paths are sufficiently robust.