### PR TITLE
Allow GetScripts() to return even if a context hasn't been created

### DIFF
--- a/lib/Debug.ProtocolHandler/Debugger.cpp
+++ b/lib/Debug.ProtocolHandler/Debugger.cpp
@@ -95,17 +95,19 @@ namespace JsDebug
     std::vector<DebuggerScript> Debugger::GetScripts()
     {
         std::vector<DebuggerScript> scripts;
-
         JsValueRef scriptsArray = JS_INVALID_REFERENCE;
-        IfJsErrorThrow(JsDiagGetScripts(&scriptsArray));
-
-        int length = PropertyHelpers::GetPropertyInt(scriptsArray, PropertyHelpers::Names::Length);
-
-        for (int index = 0; index < length; index++)
+        JsErrorCode result = JsDiagGetScripts(&scriptsArray);
+          
+        if (result == JsNoError)
         {
+          int length = PropertyHelpers::GetPropertyInt(scriptsArray, PropertyHelpers::Names::Length);
+
+          for (int index = 0; index < length; index++)
+          {
             JsValueRef scriptValue = PropertyHelpers::GetIndexedProperty(scriptsArray, index);
 
             scripts.emplace_back(scriptValue);
+          }
         }
 
         return scripts;


### PR DESCRIPTION
This allows debugging to be enabled before the JavaScript context has been created.