### PR TITLE
Remove GenerateProtocol.py from build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -289,3 +289,6 @@ __pycache__/
 
 # Don't ignore the bin folder in the root
 !/[Bb]in/
+
+# Jinja cache files
+__jinja*.cache

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Debugging companion for the ChakraCore JavaScript engine
 ## Prerequisites
 
 * Visual Studio 2017
-* Python 2.7 (must be in the PATH)
+* Python 2.7 (For generating the protocol parser only; must be in the PATH)
 
 ## Building
 

--- a/lib/Debug.Protocol/Debug.Protocol.vcxproj
+++ b/lib/Debug.Protocol/Debug.Protocol.vcxproj
@@ -82,12 +82,6 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <LinkIncremental>false</LinkIncremental>
   </PropertyGroup>
-  <ItemDefinitionGroup>
-    <PreBuildEvent>
-      <Command>python "$(ProjectDir)\GenerateProtocol.py" --generator_script "$(DepsDirectoryPath)inspector_protocol\CodeGenerator.py" --jinja_dir "$(DepsDirectoryPath)jinja\\" --markupsafe_dir "$(DepsDirectoryPath)markupsafe\\" --output_base "$(ProjectDir)$(IntermediateOutputPath)\" --config "$(ProjectDir)inspector_protocol_config.json"</Command>
-      <Message>Generating protocol definitions</Message>
-    </PreBuildEvent>
-  </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
@@ -96,7 +90,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>$(ProjectDir);$(IntermediateOutputPath);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir);$(ProjectDir)\Generated;$(IntermediateOutputPath);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -111,7 +105,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>$(ProjectDir);$(IntermediateOutputPath);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir);$(ProjectDir)\Generated;$(IntermediateOutputPath);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -128,7 +122,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>$(ProjectDir);$(IntermediateOutputPath);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir);$(ProjectDir)\Generated;$(IntermediateOutputPath);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -147,7 +141,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>$(ProjectDir);$(IntermediateOutputPath);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir);$(ProjectDir)\Generated;$(IntermediateOutputPath);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -157,26 +151,26 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <ClInclude Include="$(IntermediateOutputPath)protocol\Console.h" />
-    <ClInclude Include="$(IntermediateOutputPath)protocol\Debugger.h" />
-    <ClInclude Include="$(IntermediateOutputPath)protocol\Forward.h" />
-    <ClInclude Include="$(IntermediateOutputPath)protocol\Protocol.h" />
-    <ClInclude Include="$(IntermediateOutputPath)protocol\Runtime.h" />
-    <ClInclude Include="$(IntermediateOutputPath)protocol\Schema.h" />
-    <ClInclude Include="$(IntermediateOutputPath)include\Debugger.h" />
-    <ClInclude Include="$(IntermediateOutputPath)include\Runtime.h" />
-    <ClInclude Include="$(IntermediateOutputPath)include\Schema.h" />
     <ClInclude Include="Common.h" />
+    <ClInclude Include="Generated\include\Debugger.h" />
+    <ClInclude Include="Generated\include\Runtime.h" />
+    <ClInclude Include="Generated\include\Schema.h" />
+    <ClInclude Include="Generated\protocol\Console.h" />
+    <ClInclude Include="Generated\protocol\Debugger.h" />
+    <ClInclude Include="Generated\protocol\Forward.h" />
+    <ClInclude Include="Generated\protocol\Protocol.h" />
+    <ClInclude Include="Generated\protocol\Runtime.h" />
+    <ClInclude Include="Generated\protocol\Schema.h" />
     <ClInclude Include="String16.h" />
     <ClInclude Include="StringUtil.h" />
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="$(IntermediateOutputPath)protocol\Console.cpp" />
-    <ClCompile Include="$(IntermediateOutputPath)protocol\Debugger.cpp" />
-    <ClCompile Include="$(IntermediateOutputPath)protocol\Protocol.cpp" />
-    <ClCompile Include="$(IntermediateOutputPath)protocol\Runtime.cpp" />
-    <ClCompile Include="$(IntermediateOutputPath)protocol\Schema.cpp" />
     <ClCompile Include="Common.cpp" />
+    <ClCompile Include="Generated\protocol\Console.cpp" />
+    <ClCompile Include="Generated\protocol\Debugger.cpp" />
+    <ClCompile Include="Generated\protocol\Protocol.cpp" />
+    <ClCompile Include="Generated\protocol\Runtime.cpp" />
+    <ClCompile Include="Generated\protocol\Schema.cpp" />
     <ClCompile Include="String16.cpp" />
     <ClCompile Include="StringUtil.cpp" />
   </ItemGroup>

--- a/lib/Debug.Protocol/Debug.Protocol.vcxproj.filters
+++ b/lib/Debug.Protocol/Debug.Protocol.vcxproj.filters
@@ -5,67 +5,67 @@
       <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
       <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
     </Filter>
-    <Filter Include="Generated Files">
+    <Filter Include="Generated">
       <UniqueIdentifier>{62cca143-3a04-4e0e-91cc-c1244303556c}</UniqueIdentifier>
     </Filter>
-    <Filter Include="Generated Files\include">
-      <UniqueIdentifier>{8db701b8-81ee-4206-a006-39950e7dc46c}</UniqueIdentifier>
+    <Filter Include="Generated\include">
+      <UniqueIdentifier>{2a0478cc-dc45-479b-b0fe-fd85e6abbac2}</UniqueIdentifier>
     </Filter>
-    <Filter Include="Generated Files\protocol">
-      <UniqueIdentifier>{892e669a-43cb-4e38-8821-4aecdbfaa7e9}</UniqueIdentifier>
+    <Filter Include="Generated\protocol">
+      <UniqueIdentifier>{9323ef45-e383-416f-b812-34e230dabf91}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="$(IntermediateOutputPath)include\Debugger.h">
-      <Filter>Generated Files\include</Filter>
-    </ClInclude>
-    <ClInclude Include="$(IntermediateOutputPath)include\Runtime.h">
-      <Filter>Generated Files\include</Filter>
-    </ClInclude>
-    <ClInclude Include="$(IntermediateOutputPath)include\Schema.h">
-      <Filter>Generated Files\include</Filter>
-    </ClInclude>
-    <ClInclude Include="$(IntermediateOutputPath)protocol\Console.h">
-      <Filter>Generated Files\protocol</Filter>
-    </ClInclude>
-    <ClInclude Include="$(IntermediateOutputPath)protocol\Debugger.h">
-      <Filter>Generated Files\protocol</Filter>
-    </ClInclude>
-    <ClInclude Include="$(IntermediateOutputPath)protocol\Forward.h">
-      <Filter>Generated Files\protocol</Filter>
-    </ClInclude>
-    <ClInclude Include="$(IntermediateOutputPath)protocol\Protocol.h">
-      <Filter>Generated Files\protocol</Filter>
-    </ClInclude>
-    <ClInclude Include="$(IntermediateOutputPath)protocol\Runtime.h">
-      <Filter>Generated Files\protocol</Filter>
-    </ClInclude>
-    <ClInclude Include="$(IntermediateOutputPath)protocol\Schema.h">
-      <Filter>Generated Files\protocol</Filter>
-    </ClInclude>
     <ClInclude Include="Common.h" />
     <ClInclude Include="String16.h" />
     <ClInclude Include="StringUtil.h" />
+    <ClInclude Include="Generated\include\Debugger.h">
+      <Filter>Generated\include</Filter>
+    </ClInclude>
+    <ClInclude Include="Generated\include\Runtime.h">
+      <Filter>Generated\include</Filter>
+    </ClInclude>
+    <ClInclude Include="Generated\include\Schema.h">
+      <Filter>Generated\include</Filter>
+    </ClInclude>
+    <ClInclude Include="Generated\protocol\Schema.h">
+      <Filter>Generated\protocol</Filter>
+    </ClInclude>
+    <ClInclude Include="Generated\protocol\Console.h">
+      <Filter>Generated\protocol</Filter>
+    </ClInclude>
+    <ClInclude Include="Generated\protocol\Debugger.h">
+      <Filter>Generated\protocol</Filter>
+    </ClInclude>
+    <ClInclude Include="Generated\protocol\Forward.h">
+      <Filter>Generated\protocol</Filter>
+    </ClInclude>
+    <ClInclude Include="Generated\protocol\Protocol.h">
+      <Filter>Generated\protocol</Filter>
+    </ClInclude>
+    <ClInclude Include="Generated\protocol\Runtime.h">
+      <Filter>Generated\protocol</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="$(IntermediateOutputPath)protocol\Console.cpp">
-      <Filter>Generated Files\protocol</Filter>
-    </ClCompile>
-    <ClCompile Include="$(IntermediateOutputPath)protocol\Debugger.cpp">
-      <Filter>Generated Files\protocol</Filter>
-    </ClCompile>
-    <ClCompile Include="$(IntermediateOutputPath)protocol\Protocol.cpp">
-      <Filter>Generated Files\protocol</Filter>
-    </ClCompile>
-    <ClCompile Include="$(IntermediateOutputPath)protocol\Runtime.cpp">
-      <Filter>Generated Files\protocol</Filter>
-    </ClCompile>
-    <ClCompile Include="$(IntermediateOutputPath)protocol\Schema.cpp">
-      <Filter>Generated Files\protocol</Filter>
-    </ClCompile>
     <ClCompile Include="Common.cpp" />
     <ClCompile Include="String16.cpp" />
     <ClCompile Include="StringUtil.cpp" />
+    <ClCompile Include="Generated\protocol\Console.cpp">
+      <Filter>Generated\protocol</Filter>
+    </ClCompile>
+    <ClCompile Include="Generated\protocol\Debugger.cpp">
+      <Filter>Generated\protocol</Filter>
+    </ClCompile>
+    <ClCompile Include="Generated\protocol\Protocol.cpp">
+      <Filter>Generated\protocol</Filter>
+    </ClCompile>
+    <ClCompile Include="Generated\protocol\Runtime.cpp">
+      <Filter>Generated\protocol</Filter>
+    </ClCompile>
+    <ClCompile Include="Generated\protocol\Schema.cpp">
+      <Filter>Generated\protocol</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <None Include="inspector_protocol_config.json" />

--- a/lib/Debug.Protocol/GenerateProtocol.bat
+++ b/lib/Debug.Protocol/GenerateProtocol.bat
@@ -1,0 +1,10 @@
+@if "debug"=="" echo off
+setlocal
+
+set DEPS=%~dp0..\..\deps
+set OUTDIR=%~dp0Generated
+
+if exist "%OUTDIR%" rmdir /s /q "%OUTDIR%"
+mkdir "%OUTDIR%"
+
+python "%~dp0GenerateProtocol.py" --generator_script "%DEPS%\inspector_protocol\CodeGenerator.py" --jinja_dir "%DEPS%\jinja\\" --markupsafe_dir "%DEPS%\markupsafe\\" --output_base "%OUTDIR%\\" --config "%~dp0inspector_protocol_config.json"

--- a/lib/Debug.Protocol/Generated/include/Debugger.h
+++ b/lib/Debug.Protocol/Generated/include/Debugger.h
@@ -1,0 +1,46 @@
+// This file is generated
+
+// Copyright (c) 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef JsDebug_protocol_Debugger_api_h
+#define JsDebug_protocol_Debugger_api_h
+
+#include "Common.h"
+
+namespace JsDebug {
+namespace protocol {
+namespace Debugger {
+namespace API {
+
+// ------------- Enums.
+
+namespace Paused {
+namespace ReasonEnum {
+LIB_EXPORT extern const char* XHR;
+LIB_EXPORT extern const char* DOM;
+LIB_EXPORT extern const char* EventListener;
+LIB_EXPORT extern const char* Exception;
+LIB_EXPORT extern const char* Assert;
+LIB_EXPORT extern const char* DebugCommand;
+LIB_EXPORT extern const char* PromiseRejection;
+LIB_EXPORT extern const char* Other;
+} // ReasonEnum
+} // Paused
+
+// ------------- Types.
+
+class LIB_EXPORT SearchMatch {
+public:
+    virtual std::unique_ptr<StringBuffer> toJSONString() const = 0;
+    virtual ~SearchMatch() { }
+    static std::unique_ptr<protocol::Debugger::API::SearchMatch> fromJSONString(const StringView& json);
+};
+
+} // namespace API
+} // namespace Debugger
+} // namespace JsDebug
+} // namespace protocol
+
+#endif // !defined(JsDebug_protocol_Debugger_api_h)

--- a/lib/Debug.Protocol/Generated/include/Runtime.h
+++ b/lib/Debug.Protocol/Generated/include/Runtime.h
@@ -1,0 +1,40 @@
+// This file is generated
+
+// Copyright (c) 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef JsDebug_protocol_Runtime_api_h
+#define JsDebug_protocol_Runtime_api_h
+
+#include "Common.h"
+
+namespace JsDebug {
+namespace protocol {
+namespace Runtime {
+namespace API {
+
+// ------------- Enums.
+
+// ------------- Types.
+
+class LIB_EXPORT RemoteObject {
+public:
+    virtual std::unique_ptr<StringBuffer> toJSONString() const = 0;
+    virtual ~RemoteObject() { }
+    static std::unique_ptr<protocol::Runtime::API::RemoteObject> fromJSONString(const StringView& json);
+};
+
+class LIB_EXPORT StackTrace {
+public:
+    virtual std::unique_ptr<StringBuffer> toJSONString() const = 0;
+    virtual ~StackTrace() { }
+    static std::unique_ptr<protocol::Runtime::API::StackTrace> fromJSONString(const StringView& json);
+};
+
+} // namespace API
+} // namespace Runtime
+} // namespace JsDebug
+} // namespace protocol
+
+#endif // !defined(JsDebug_protocol_Runtime_api_h)

--- a/lib/Debug.Protocol/Generated/include/Schema.h
+++ b/lib/Debug.Protocol/Generated/include/Schema.h
@@ -1,0 +1,33 @@
+// This file is generated
+
+// Copyright (c) 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef JsDebug_protocol_Schema_api_h
+#define JsDebug_protocol_Schema_api_h
+
+#include "Common.h"
+
+namespace JsDebug {
+namespace protocol {
+namespace Schema {
+namespace API {
+
+// ------------- Enums.
+
+// ------------- Types.
+
+class LIB_EXPORT Domain {
+public:
+    virtual std::unique_ptr<StringBuffer> toJSONString() const = 0;
+    virtual ~Domain() { }
+    static std::unique_ptr<protocol::Schema::API::Domain> fromJSONString(const StringView& json);
+};
+
+} // namespace API
+} // namespace Schema
+} // namespace JsDebug
+} // namespace protocol
+
+#endif // !defined(JsDebug_protocol_Schema_api_h)

--- a/lib/Debug.Protocol/Generated/protocol/Console.cpp
+++ b/lib/Debug.Protocol/Generated/protocol/Console.cpp
@@ -1,0 +1,248 @@
+// This file is generated
+
+// Copyright (c) 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "protocol/Console.h"
+
+#include "protocol/Protocol.h"
+
+namespace JsDebug {
+namespace protocol {
+namespace Console {
+
+// ------------- Enum values from types.
+
+const char Metainfo::domainName[] = "Console";
+const char Metainfo::commandPrefix[] = "Console.";
+const char Metainfo::version[] = "1.2";
+
+const char* ConsoleMessage::SourceEnum::Xml = "xml";
+const char* ConsoleMessage::SourceEnum::Javascript = "javascript";
+const char* ConsoleMessage::SourceEnum::Network = "network";
+const char* ConsoleMessage::SourceEnum::ConsoleApi = "console-api";
+const char* ConsoleMessage::SourceEnum::Storage = "storage";
+const char* ConsoleMessage::SourceEnum::Appcache = "appcache";
+const char* ConsoleMessage::SourceEnum::Rendering = "rendering";
+const char* ConsoleMessage::SourceEnum::Security = "security";
+const char* ConsoleMessage::SourceEnum::Other = "other";
+const char* ConsoleMessage::SourceEnum::Deprecation = "deprecation";
+const char* ConsoleMessage::SourceEnum::Worker = "worker";
+
+const char* ConsoleMessage::LevelEnum::Log = "log";
+const char* ConsoleMessage::LevelEnum::Warning = "warning";
+const char* ConsoleMessage::LevelEnum::Error = "error";
+const char* ConsoleMessage::LevelEnum::Debug = "debug";
+const char* ConsoleMessage::LevelEnum::Info = "info";
+
+std::unique_ptr<ConsoleMessage> ConsoleMessage::fromValue(protocol::Value* value, ErrorSupport* errors)
+{
+    if (!value || value->type() != protocol::Value::TypeObject) {
+        errors->addError("object expected");
+        return nullptr;
+    }
+
+    std::unique_ptr<ConsoleMessage> result(new ConsoleMessage());
+    protocol::DictionaryValue* object = DictionaryValue::cast(value);
+    errors->push();
+    protocol::Value* sourceValue = object->get("source");
+    errors->setName("source");
+    result->m_source = ValueConversions<String>::fromValue(sourceValue, errors);
+    protocol::Value* levelValue = object->get("level");
+    errors->setName("level");
+    result->m_level = ValueConversions<String>::fromValue(levelValue, errors);
+    protocol::Value* textValue = object->get("text");
+    errors->setName("text");
+    result->m_text = ValueConversions<String>::fromValue(textValue, errors);
+    protocol::Value* urlValue = object->get("url");
+    if (urlValue) {
+        errors->setName("url");
+        result->m_url = ValueConversions<String>::fromValue(urlValue, errors);
+    }
+    protocol::Value* lineValue = object->get("line");
+    if (lineValue) {
+        errors->setName("line");
+        result->m_line = ValueConversions<int>::fromValue(lineValue, errors);
+    }
+    protocol::Value* columnValue = object->get("column");
+    if (columnValue) {
+        errors->setName("column");
+        result->m_column = ValueConversions<int>::fromValue(columnValue, errors);
+    }
+    errors->pop();
+    if (errors->hasErrors())
+        return nullptr;
+    return result;
+}
+
+std::unique_ptr<protocol::DictionaryValue> ConsoleMessage::toValue() const
+{
+    std::unique_ptr<protocol::DictionaryValue> result = DictionaryValue::create();
+    result->setValue("source", ValueConversions<String>::toValue(m_source));
+    result->setValue("level", ValueConversions<String>::toValue(m_level));
+    result->setValue("text", ValueConversions<String>::toValue(m_text));
+    if (m_url.isJust())
+        result->setValue("url", ValueConversions<String>::toValue(m_url.fromJust()));
+    if (m_line.isJust())
+        result->setValue("line", ValueConversions<int>::toValue(m_line.fromJust()));
+    if (m_column.isJust())
+        result->setValue("column", ValueConversions<int>::toValue(m_column.fromJust()));
+    return result;
+}
+
+std::unique_ptr<ConsoleMessage> ConsoleMessage::clone() const
+{
+    ErrorSupport errors;
+    return fromValue(toValue().get(), &errors);
+}
+
+std::unique_ptr<MessageAddedNotification> MessageAddedNotification::fromValue(protocol::Value* value, ErrorSupport* errors)
+{
+    if (!value || value->type() != protocol::Value::TypeObject) {
+        errors->addError("object expected");
+        return nullptr;
+    }
+
+    std::unique_ptr<MessageAddedNotification> result(new MessageAddedNotification());
+    protocol::DictionaryValue* object = DictionaryValue::cast(value);
+    errors->push();
+    protocol::Value* messageValue = object->get("message");
+    errors->setName("message");
+    result->m_message = ValueConversions<protocol::Console::ConsoleMessage>::fromValue(messageValue, errors);
+    errors->pop();
+    if (errors->hasErrors())
+        return nullptr;
+    return result;
+}
+
+std::unique_ptr<protocol::DictionaryValue> MessageAddedNotification::toValue() const
+{
+    std::unique_ptr<protocol::DictionaryValue> result = DictionaryValue::create();
+    result->setValue("message", ValueConversions<protocol::Console::ConsoleMessage>::toValue(m_message.get()));
+    return result;
+}
+
+std::unique_ptr<MessageAddedNotification> MessageAddedNotification::clone() const
+{
+    ErrorSupport errors;
+    return fromValue(toValue().get(), &errors);
+}
+
+// ------------- Enum values from params.
+
+
+// ------------- Frontend notifications.
+
+void Frontend::messageAdded(std::unique_ptr<protocol::Console::ConsoleMessage> message)
+{
+    if (!m_frontendChannel)
+        return;
+    std::unique_ptr<MessageAddedNotification> messageData = MessageAddedNotification::create()
+        .setMessage(std::move(message))
+        .build();
+    m_frontendChannel->sendProtocolNotification(InternalResponse::createNotification("Console.messageAdded", std::move(messageData)));
+}
+
+void Frontend::flush()
+{
+    m_frontendChannel->flushProtocolNotifications();
+}
+
+void Frontend::sendRawNotification(const String& notification)
+{
+    m_frontendChannel->sendProtocolNotification(InternalRawNotification::create(notification));
+}
+
+// --------------------- Dispatcher.
+
+class DispatcherImpl : public protocol::DispatcherBase {
+public:
+    DispatcherImpl(FrontendChannel* frontendChannel, Backend* backend, bool fallThroughForNotFound)
+        : DispatcherBase(frontendChannel)
+        , m_backend(backend)
+        , m_fallThroughForNotFound(fallThroughForNotFound) {
+        m_dispatchMap["Console.enable"] = &DispatcherImpl::enable;
+        m_dispatchMap["Console.disable"] = &DispatcherImpl::disable;
+        m_dispatchMap["Console.clearMessages"] = &DispatcherImpl::clearMessages;
+    }
+    ~DispatcherImpl() override { }
+    DispatchResponse::Status dispatch(int callId, const String& method, std::unique_ptr<protocol::DictionaryValue> messageObject) override;
+    HashMap<String, String>& redirects() { return m_redirects; }
+
+protected:
+    using CallHandler = DispatchResponse::Status (DispatcherImpl::*)(int callId, std::unique_ptr<DictionaryValue> messageObject, ErrorSupport* errors);
+    using DispatchMap = protocol::HashMap<String, CallHandler>;
+    DispatchMap m_dispatchMap;
+    HashMap<String, String> m_redirects;
+
+    DispatchResponse::Status enable(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport*);
+    DispatchResponse::Status disable(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport*);
+    DispatchResponse::Status clearMessages(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport*);
+
+    Backend* m_backend;
+    bool m_fallThroughForNotFound;
+};
+
+DispatchResponse::Status DispatcherImpl::dispatch(int callId, const String& method, std::unique_ptr<protocol::DictionaryValue> messageObject)
+{
+    protocol::HashMap<String, CallHandler>::iterator it = m_dispatchMap.find(method);
+    if (it == m_dispatchMap.end()) {
+        if (m_fallThroughForNotFound)
+            return DispatchResponse::kFallThrough;
+        reportProtocolError(callId, DispatchResponse::kMethodNotFound, "'" + method + "' wasn't found", nullptr);
+        return DispatchResponse::kError;
+    }
+
+    protocol::ErrorSupport errors;
+    return (this->*(it->second))(callId, std::move(messageObject), &errors);
+}
+
+
+DispatchResponse::Status DispatcherImpl::enable(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport* errors)
+{
+
+    std::unique_ptr<DispatcherBase::WeakPtr> weak = weakPtr();
+    DispatchResponse response = m_backend->enable();
+    if (response.status() == DispatchResponse::kFallThrough)
+        return response.status();
+    if (weak->get())
+        weak->get()->sendResponse(callId, response);
+    return response.status();
+}
+
+DispatchResponse::Status DispatcherImpl::disable(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport* errors)
+{
+
+    std::unique_ptr<DispatcherBase::WeakPtr> weak = weakPtr();
+    DispatchResponse response = m_backend->disable();
+    if (response.status() == DispatchResponse::kFallThrough)
+        return response.status();
+    if (weak->get())
+        weak->get()->sendResponse(callId, response);
+    return response.status();
+}
+
+DispatchResponse::Status DispatcherImpl::clearMessages(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport* errors)
+{
+
+    std::unique_ptr<DispatcherBase::WeakPtr> weak = weakPtr();
+    DispatchResponse response = m_backend->clearMessages();
+    if (response.status() == DispatchResponse::kFallThrough)
+        return response.status();
+    if (weak->get())
+        weak->get()->sendResponse(callId, response);
+    return response.status();
+}
+
+// static
+void Dispatcher::wire(UberDispatcher* uber, Backend* backend)
+{
+    std::unique_ptr<DispatcherImpl> dispatcher(new DispatcherImpl(uber->channel(), backend, uber->fallThroughForNotFound()));
+    uber->setupRedirects(dispatcher->redirects());
+    uber->registerBackend("Console", std::move(dispatcher));
+}
+
+} // Console
+} // namespace JsDebug
+} // namespace protocol

--- a/lib/Debug.Protocol/Generated/protocol/Console.h
+++ b/lib/Debug.Protocol/Generated/protocol/Console.h
@@ -1,0 +1,279 @@
+// This file is generated
+
+// Copyright (c) 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef JsDebug_protocol_Console_h
+#define JsDebug_protocol_Console_h
+
+#include "protocol/Protocol.h"
+// For each imported domain we generate a ValueConversions struct instead of a full domain definition
+// and include Domain::API version from there.
+#include "protocol/Runtime.h"
+
+namespace JsDebug {
+namespace protocol {
+namespace Console {
+
+// ------------- Forward and enum declarations.
+class ConsoleMessage;
+class MessageAddedNotification;
+
+// ------------- Type and builder declarations.
+
+class  ConsoleMessage : public Serializable{
+    PROTOCOL_DISALLOW_COPY(ConsoleMessage);
+public:
+    static std::unique_ptr<ConsoleMessage> fromValue(protocol::Value* value, ErrorSupport* errors);
+
+    ~ConsoleMessage() override { }
+
+    struct  SourceEnum {
+        static const char* Xml;
+        static const char* Javascript;
+        static const char* Network;
+        static const char* ConsoleApi;
+        static const char* Storage;
+        static const char* Appcache;
+        static const char* Rendering;
+        static const char* Security;
+        static const char* Other;
+        static const char* Deprecation;
+        static const char* Worker;
+    }; // SourceEnum
+
+    String getSource() { return m_source; }
+    void setSource(const String& value) { m_source = value; }
+
+    struct  LevelEnum {
+        static const char* Log;
+        static const char* Warning;
+        static const char* Error;
+        static const char* Debug;
+        static const char* Info;
+    }; // LevelEnum
+
+    String getLevel() { return m_level; }
+    void setLevel(const String& value) { m_level = value; }
+
+    String getText() { return m_text; }
+    void setText(const String& value) { m_text = value; }
+
+    bool hasUrl() { return m_url.isJust(); }
+    String getUrl(const String& defaultValue) { return m_url.isJust() ? m_url.fromJust() : defaultValue; }
+    void setUrl(const String& value) { m_url = value; }
+
+    bool hasLine() { return m_line.isJust(); }
+    int getLine(int defaultValue) { return m_line.isJust() ? m_line.fromJust() : defaultValue; }
+    void setLine(int value) { m_line = value; }
+
+    bool hasColumn() { return m_column.isJust(); }
+    int getColumn(int defaultValue) { return m_column.isJust() ? m_column.fromJust() : defaultValue; }
+    void setColumn(int value) { m_column = value; }
+
+    std::unique_ptr<protocol::DictionaryValue> toValue() const;
+    String serialize() override { return toValue()->serialize(); }
+    std::unique_ptr<ConsoleMessage> clone() const;
+
+    template<int STATE>
+    class ConsoleMessageBuilder {
+    public:
+        enum {
+            NoFieldsSet = 0,
+            SourceSet = 1 << 1,
+            LevelSet = 1 << 2,
+            TextSet = 1 << 3,
+            AllFieldsSet = (SourceSet | LevelSet | TextSet | 0)};
+
+
+        ConsoleMessageBuilder<STATE | SourceSet>& setSource(const String& value)
+        {
+            static_assert(!(STATE & SourceSet), "property source should not be set yet");
+            m_result->setSource(value);
+            return castState<SourceSet>();
+        }
+
+        ConsoleMessageBuilder<STATE | LevelSet>& setLevel(const String& value)
+        {
+            static_assert(!(STATE & LevelSet), "property level should not be set yet");
+            m_result->setLevel(value);
+            return castState<LevelSet>();
+        }
+
+        ConsoleMessageBuilder<STATE | TextSet>& setText(const String& value)
+        {
+            static_assert(!(STATE & TextSet), "property text should not be set yet");
+            m_result->setText(value);
+            return castState<TextSet>();
+        }
+
+        ConsoleMessageBuilder<STATE>& setUrl(const String& value)
+        {
+            m_result->setUrl(value);
+            return *this;
+        }
+
+        ConsoleMessageBuilder<STATE>& setLine(int value)
+        {
+            m_result->setLine(value);
+            return *this;
+        }
+
+        ConsoleMessageBuilder<STATE>& setColumn(int value)
+        {
+            m_result->setColumn(value);
+            return *this;
+        }
+
+        std::unique_ptr<ConsoleMessage> build()
+        {
+            static_assert(STATE == AllFieldsSet, "state should be AllFieldsSet");
+            return std::move(m_result);
+        }
+
+    private:
+        friend class ConsoleMessage;
+        ConsoleMessageBuilder() : m_result(new ConsoleMessage()) { }
+
+        template<int STEP> ConsoleMessageBuilder<STATE | STEP>& castState()
+        {
+            return *reinterpret_cast<ConsoleMessageBuilder<STATE | STEP>*>(this);
+        }
+
+        std::unique_ptr<protocol::Console::ConsoleMessage> m_result;
+    };
+
+    static ConsoleMessageBuilder<0> create()
+    {
+        return ConsoleMessageBuilder<0>();
+    }
+
+private:
+    ConsoleMessage()
+    {
+    }
+
+    String m_source;
+    String m_level;
+    String m_text;
+    Maybe<String> m_url;
+    Maybe<int> m_line;
+    Maybe<int> m_column;
+};
+
+
+class  MessageAddedNotification : public Serializable{
+    PROTOCOL_DISALLOW_COPY(MessageAddedNotification);
+public:
+    static std::unique_ptr<MessageAddedNotification> fromValue(protocol::Value* value, ErrorSupport* errors);
+
+    ~MessageAddedNotification() override { }
+
+    protocol::Console::ConsoleMessage* getMessage() { return m_message.get(); }
+    void setMessage(std::unique_ptr<protocol::Console::ConsoleMessage> value) { m_message = std::move(value); }
+
+    std::unique_ptr<protocol::DictionaryValue> toValue() const;
+    String serialize() override { return toValue()->serialize(); }
+    std::unique_ptr<MessageAddedNotification> clone() const;
+
+    template<int STATE>
+    class MessageAddedNotificationBuilder {
+    public:
+        enum {
+            NoFieldsSet = 0,
+            MessageSet = 1 << 1,
+            AllFieldsSet = (MessageSet | 0)};
+
+
+        MessageAddedNotificationBuilder<STATE | MessageSet>& setMessage(std::unique_ptr<protocol::Console::ConsoleMessage> value)
+        {
+            static_assert(!(STATE & MessageSet), "property message should not be set yet");
+            m_result->setMessage(std::move(value));
+            return castState<MessageSet>();
+        }
+
+        std::unique_ptr<MessageAddedNotification> build()
+        {
+            static_assert(STATE == AllFieldsSet, "state should be AllFieldsSet");
+            return std::move(m_result);
+        }
+
+    private:
+        friend class MessageAddedNotification;
+        MessageAddedNotificationBuilder() : m_result(new MessageAddedNotification()) { }
+
+        template<int STEP> MessageAddedNotificationBuilder<STATE | STEP>& castState()
+        {
+            return *reinterpret_cast<MessageAddedNotificationBuilder<STATE | STEP>*>(this);
+        }
+
+        std::unique_ptr<protocol::Console::MessageAddedNotification> m_result;
+    };
+
+    static MessageAddedNotificationBuilder<0> create()
+    {
+        return MessageAddedNotificationBuilder<0>();
+    }
+
+private:
+    MessageAddedNotification()
+    {
+    }
+
+    std::unique_ptr<protocol::Console::ConsoleMessage> m_message;
+};
+
+
+// ------------- Backend interface.
+
+class  Backend {
+public:
+    virtual ~Backend() { }
+
+    virtual DispatchResponse enable() = 0;
+    virtual DispatchResponse disable() = 0;
+    virtual DispatchResponse clearMessages() = 0;
+
+};
+
+// ------------- Frontend interface.
+
+class  Frontend {
+public:
+    explicit Frontend(FrontendChannel* frontendChannel) : m_frontendChannel(frontendChannel) { }
+    void messageAdded(std::unique_ptr<protocol::Console::ConsoleMessage> message);
+
+    void flush();
+    void sendRawNotification(const String&);
+private:
+    FrontendChannel* m_frontendChannel;
+};
+
+// ------------- Dispatcher.
+
+class  Dispatcher {
+public:
+    static void wire(UberDispatcher*, Backend*);
+
+private:
+    Dispatcher() { }
+};
+
+// ------------- Metainfo.
+
+class  Metainfo {
+public:
+    using BackendClass = Backend;
+    using FrontendClass = Frontend;
+    using DispatcherClass = Dispatcher;
+    static const char domainName[];
+    static const char commandPrefix[];
+    static const char version[];
+};
+
+} // namespace Console
+} // namespace JsDebug
+} // namespace protocol
+
+#endif // !defined(JsDebug_protocol_Console_h)

--- a/lib/Debug.Protocol/Generated/protocol/Debugger.cpp
+++ b/lib/Debug.Protocol/Generated/protocol/Debugger.cpp
@@ -1,0 +1,1392 @@
+// This file is generated
+
+// Copyright (c) 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "protocol/Debugger.h"
+
+#include "protocol/Protocol.h"
+
+namespace JsDebug {
+namespace protocol {
+namespace Debugger {
+
+// ------------- Enum values from types.
+
+const char Metainfo::domainName[] = "Debugger";
+const char Metainfo::commandPrefix[] = "Debugger.";
+const char Metainfo::version[] = "1.2";
+
+std::unique_ptr<Location> Location::fromValue(protocol::Value* value, ErrorSupport* errors)
+{
+    if (!value || value->type() != protocol::Value::TypeObject) {
+        errors->addError("object expected");
+        return nullptr;
+    }
+
+    std::unique_ptr<Location> result(new Location());
+    protocol::DictionaryValue* object = DictionaryValue::cast(value);
+    errors->push();
+    protocol::Value* scriptIdValue = object->get("scriptId");
+    errors->setName("scriptId");
+    result->m_scriptId = ValueConversions<String>::fromValue(scriptIdValue, errors);
+    protocol::Value* lineNumberValue = object->get("lineNumber");
+    errors->setName("lineNumber");
+    result->m_lineNumber = ValueConversions<int>::fromValue(lineNumberValue, errors);
+    protocol::Value* columnNumberValue = object->get("columnNumber");
+    if (columnNumberValue) {
+        errors->setName("columnNumber");
+        result->m_columnNumber = ValueConversions<int>::fromValue(columnNumberValue, errors);
+    }
+    errors->pop();
+    if (errors->hasErrors())
+        return nullptr;
+    return result;
+}
+
+std::unique_ptr<protocol::DictionaryValue> Location::toValue() const
+{
+    std::unique_ptr<protocol::DictionaryValue> result = DictionaryValue::create();
+    result->setValue("scriptId", ValueConversions<String>::toValue(m_scriptId));
+    result->setValue("lineNumber", ValueConversions<int>::toValue(m_lineNumber));
+    if (m_columnNumber.isJust())
+        result->setValue("columnNumber", ValueConversions<int>::toValue(m_columnNumber.fromJust()));
+    return result;
+}
+
+std::unique_ptr<Location> Location::clone() const
+{
+    ErrorSupport errors;
+    return fromValue(toValue().get(), &errors);
+}
+
+std::unique_ptr<ScriptPosition> ScriptPosition::fromValue(protocol::Value* value, ErrorSupport* errors)
+{
+    if (!value || value->type() != protocol::Value::TypeObject) {
+        errors->addError("object expected");
+        return nullptr;
+    }
+
+    std::unique_ptr<ScriptPosition> result(new ScriptPosition());
+    protocol::DictionaryValue* object = DictionaryValue::cast(value);
+    errors->push();
+    protocol::Value* lineNumberValue = object->get("lineNumber");
+    errors->setName("lineNumber");
+    result->m_lineNumber = ValueConversions<int>::fromValue(lineNumberValue, errors);
+    protocol::Value* columnNumberValue = object->get("columnNumber");
+    errors->setName("columnNumber");
+    result->m_columnNumber = ValueConversions<int>::fromValue(columnNumberValue, errors);
+    errors->pop();
+    if (errors->hasErrors())
+        return nullptr;
+    return result;
+}
+
+std::unique_ptr<protocol::DictionaryValue> ScriptPosition::toValue() const
+{
+    std::unique_ptr<protocol::DictionaryValue> result = DictionaryValue::create();
+    result->setValue("lineNumber", ValueConversions<int>::toValue(m_lineNumber));
+    result->setValue("columnNumber", ValueConversions<int>::toValue(m_columnNumber));
+    return result;
+}
+
+std::unique_ptr<ScriptPosition> ScriptPosition::clone() const
+{
+    ErrorSupport errors;
+    return fromValue(toValue().get(), &errors);
+}
+
+std::unique_ptr<CallFrame> CallFrame::fromValue(protocol::Value* value, ErrorSupport* errors)
+{
+    if (!value || value->type() != protocol::Value::TypeObject) {
+        errors->addError("object expected");
+        return nullptr;
+    }
+
+    std::unique_ptr<CallFrame> result(new CallFrame());
+    protocol::DictionaryValue* object = DictionaryValue::cast(value);
+    errors->push();
+    protocol::Value* callFrameIdValue = object->get("callFrameId");
+    errors->setName("callFrameId");
+    result->m_callFrameId = ValueConversions<String>::fromValue(callFrameIdValue, errors);
+    protocol::Value* functionNameValue = object->get("functionName");
+    errors->setName("functionName");
+    result->m_functionName = ValueConversions<String>::fromValue(functionNameValue, errors);
+    protocol::Value* functionLocationValue = object->get("functionLocation");
+    if (functionLocationValue) {
+        errors->setName("functionLocation");
+        result->m_functionLocation = ValueConversions<protocol::Debugger::Location>::fromValue(functionLocationValue, errors);
+    }
+    protocol::Value* locationValue = object->get("location");
+    errors->setName("location");
+    result->m_location = ValueConversions<protocol::Debugger::Location>::fromValue(locationValue, errors);
+    protocol::Value* scopeChainValue = object->get("scopeChain");
+    errors->setName("scopeChain");
+    result->m_scopeChain = ValueConversions<protocol::Array<protocol::Debugger::Scope>>::fromValue(scopeChainValue, errors);
+    protocol::Value* thisValue = object->get("this");
+    errors->setName("this");
+    result->m_this = ValueConversions<protocol::Runtime::RemoteObject>::fromValue(thisValue, errors);
+    protocol::Value* returnValueValue = object->get("returnValue");
+    if (returnValueValue) {
+        errors->setName("returnValue");
+        result->m_returnValue = ValueConversions<protocol::Runtime::RemoteObject>::fromValue(returnValueValue, errors);
+    }
+    errors->pop();
+    if (errors->hasErrors())
+        return nullptr;
+    return result;
+}
+
+std::unique_ptr<protocol::DictionaryValue> CallFrame::toValue() const
+{
+    std::unique_ptr<protocol::DictionaryValue> result = DictionaryValue::create();
+    result->setValue("callFrameId", ValueConversions<String>::toValue(m_callFrameId));
+    result->setValue("functionName", ValueConversions<String>::toValue(m_functionName));
+    if (m_functionLocation.isJust())
+        result->setValue("functionLocation", ValueConversions<protocol::Debugger::Location>::toValue(m_functionLocation.fromJust()));
+    result->setValue("location", ValueConversions<protocol::Debugger::Location>::toValue(m_location.get()));
+    result->setValue("scopeChain", ValueConversions<protocol::Array<protocol::Debugger::Scope>>::toValue(m_scopeChain.get()));
+    result->setValue("this", ValueConversions<protocol::Runtime::RemoteObject>::toValue(m_this.get()));
+    if (m_returnValue.isJust())
+        result->setValue("returnValue", ValueConversions<protocol::Runtime::RemoteObject>::toValue(m_returnValue.fromJust()));
+    return result;
+}
+
+std::unique_ptr<CallFrame> CallFrame::clone() const
+{
+    ErrorSupport errors;
+    return fromValue(toValue().get(), &errors);
+}
+
+const char* Scope::TypeEnum::Global = "global";
+const char* Scope::TypeEnum::Local = "local";
+const char* Scope::TypeEnum::With = "with";
+const char* Scope::TypeEnum::Closure = "closure";
+const char* Scope::TypeEnum::Catch = "catch";
+const char* Scope::TypeEnum::Block = "block";
+const char* Scope::TypeEnum::Script = "script";
+
+std::unique_ptr<Scope> Scope::fromValue(protocol::Value* value, ErrorSupport* errors)
+{
+    if (!value || value->type() != protocol::Value::TypeObject) {
+        errors->addError("object expected");
+        return nullptr;
+    }
+
+    std::unique_ptr<Scope> result(new Scope());
+    protocol::DictionaryValue* object = DictionaryValue::cast(value);
+    errors->push();
+    protocol::Value* typeValue = object->get("type");
+    errors->setName("type");
+    result->m_type = ValueConversions<String>::fromValue(typeValue, errors);
+    protocol::Value* objectValue = object->get("object");
+    errors->setName("object");
+    result->m_object = ValueConversions<protocol::Runtime::RemoteObject>::fromValue(objectValue, errors);
+    protocol::Value* nameValue = object->get("name");
+    if (nameValue) {
+        errors->setName("name");
+        result->m_name = ValueConversions<String>::fromValue(nameValue, errors);
+    }
+    protocol::Value* startLocationValue = object->get("startLocation");
+    if (startLocationValue) {
+        errors->setName("startLocation");
+        result->m_startLocation = ValueConversions<protocol::Debugger::Location>::fromValue(startLocationValue, errors);
+    }
+    protocol::Value* endLocationValue = object->get("endLocation");
+    if (endLocationValue) {
+        errors->setName("endLocation");
+        result->m_endLocation = ValueConversions<protocol::Debugger::Location>::fromValue(endLocationValue, errors);
+    }
+    errors->pop();
+    if (errors->hasErrors())
+        return nullptr;
+    return result;
+}
+
+std::unique_ptr<protocol::DictionaryValue> Scope::toValue() const
+{
+    std::unique_ptr<protocol::DictionaryValue> result = DictionaryValue::create();
+    result->setValue("type", ValueConversions<String>::toValue(m_type));
+    result->setValue("object", ValueConversions<protocol::Runtime::RemoteObject>::toValue(m_object.get()));
+    if (m_name.isJust())
+        result->setValue("name", ValueConversions<String>::toValue(m_name.fromJust()));
+    if (m_startLocation.isJust())
+        result->setValue("startLocation", ValueConversions<protocol::Debugger::Location>::toValue(m_startLocation.fromJust()));
+    if (m_endLocation.isJust())
+        result->setValue("endLocation", ValueConversions<protocol::Debugger::Location>::toValue(m_endLocation.fromJust()));
+    return result;
+}
+
+std::unique_ptr<Scope> Scope::clone() const
+{
+    ErrorSupport errors;
+    return fromValue(toValue().get(), &errors);
+}
+
+std::unique_ptr<SearchMatch> SearchMatch::fromValue(protocol::Value* value, ErrorSupport* errors)
+{
+    if (!value || value->type() != protocol::Value::TypeObject) {
+        errors->addError("object expected");
+        return nullptr;
+    }
+
+    std::unique_ptr<SearchMatch> result(new SearchMatch());
+    protocol::DictionaryValue* object = DictionaryValue::cast(value);
+    errors->push();
+    protocol::Value* lineNumberValue = object->get("lineNumber");
+    errors->setName("lineNumber");
+    result->m_lineNumber = ValueConversions<double>::fromValue(lineNumberValue, errors);
+    protocol::Value* lineContentValue = object->get("lineContent");
+    errors->setName("lineContent");
+    result->m_lineContent = ValueConversions<String>::fromValue(lineContentValue, errors);
+    errors->pop();
+    if (errors->hasErrors())
+        return nullptr;
+    return result;
+}
+
+std::unique_ptr<protocol::DictionaryValue> SearchMatch::toValue() const
+{
+    std::unique_ptr<protocol::DictionaryValue> result = DictionaryValue::create();
+    result->setValue("lineNumber", ValueConversions<double>::toValue(m_lineNumber));
+    result->setValue("lineContent", ValueConversions<String>::toValue(m_lineContent));
+    return result;
+}
+
+std::unique_ptr<SearchMatch> SearchMatch::clone() const
+{
+    ErrorSupport errors;
+    return fromValue(toValue().get(), &errors);
+}
+
+std::unique_ptr<StringBuffer> SearchMatch::toJSONString() const
+{
+    String json = toValue()->serialize();
+    return StringBufferImpl::adopt(json);
+}
+
+// static
+std::unique_ptr<API::SearchMatch> API::SearchMatch::fromJSONString(const StringView& json)
+{
+    ErrorSupport errors;
+    std::unique_ptr<Value> value = StringUtil::parseJSON(json);
+    if (!value)
+        return nullptr;
+    return protocol::Debugger::SearchMatch::fromValue(value.get(), &errors);
+}
+
+std::unique_ptr<ScriptParsedNotification> ScriptParsedNotification::fromValue(protocol::Value* value, ErrorSupport* errors)
+{
+    if (!value || value->type() != protocol::Value::TypeObject) {
+        errors->addError("object expected");
+        return nullptr;
+    }
+
+    std::unique_ptr<ScriptParsedNotification> result(new ScriptParsedNotification());
+    protocol::DictionaryValue* object = DictionaryValue::cast(value);
+    errors->push();
+    protocol::Value* scriptIdValue = object->get("scriptId");
+    errors->setName("scriptId");
+    result->m_scriptId = ValueConversions<String>::fromValue(scriptIdValue, errors);
+    protocol::Value* urlValue = object->get("url");
+    errors->setName("url");
+    result->m_url = ValueConversions<String>::fromValue(urlValue, errors);
+    protocol::Value* startLineValue = object->get("startLine");
+    errors->setName("startLine");
+    result->m_startLine = ValueConversions<int>::fromValue(startLineValue, errors);
+    protocol::Value* startColumnValue = object->get("startColumn");
+    errors->setName("startColumn");
+    result->m_startColumn = ValueConversions<int>::fromValue(startColumnValue, errors);
+    protocol::Value* endLineValue = object->get("endLine");
+    errors->setName("endLine");
+    result->m_endLine = ValueConversions<int>::fromValue(endLineValue, errors);
+    protocol::Value* endColumnValue = object->get("endColumn");
+    errors->setName("endColumn");
+    result->m_endColumn = ValueConversions<int>::fromValue(endColumnValue, errors);
+    protocol::Value* executionContextIdValue = object->get("executionContextId");
+    errors->setName("executionContextId");
+    result->m_executionContextId = ValueConversions<int>::fromValue(executionContextIdValue, errors);
+    protocol::Value* hashValue = object->get("hash");
+    errors->setName("hash");
+    result->m_hash = ValueConversions<String>::fromValue(hashValue, errors);
+    protocol::Value* executionContextAuxDataValue = object->get("executionContextAuxData");
+    if (executionContextAuxDataValue) {
+        errors->setName("executionContextAuxData");
+        result->m_executionContextAuxData = ValueConversions<protocol::DictionaryValue>::fromValue(executionContextAuxDataValue, errors);
+    }
+    protocol::Value* isLiveEditValue = object->get("isLiveEdit");
+    if (isLiveEditValue) {
+        errors->setName("isLiveEdit");
+        result->m_isLiveEdit = ValueConversions<bool>::fromValue(isLiveEditValue, errors);
+    }
+    protocol::Value* sourceMapURLValue = object->get("sourceMapURL");
+    if (sourceMapURLValue) {
+        errors->setName("sourceMapURL");
+        result->m_sourceMapURL = ValueConversions<String>::fromValue(sourceMapURLValue, errors);
+    }
+    protocol::Value* hasSourceURLValue = object->get("hasSourceURL");
+    if (hasSourceURLValue) {
+        errors->setName("hasSourceURL");
+        result->m_hasSourceURL = ValueConversions<bool>::fromValue(hasSourceURLValue, errors);
+    }
+    errors->pop();
+    if (errors->hasErrors())
+        return nullptr;
+    return result;
+}
+
+std::unique_ptr<protocol::DictionaryValue> ScriptParsedNotification::toValue() const
+{
+    std::unique_ptr<protocol::DictionaryValue> result = DictionaryValue::create();
+    result->setValue("scriptId", ValueConversions<String>::toValue(m_scriptId));
+    result->setValue("url", ValueConversions<String>::toValue(m_url));
+    result->setValue("startLine", ValueConversions<int>::toValue(m_startLine));
+    result->setValue("startColumn", ValueConversions<int>::toValue(m_startColumn));
+    result->setValue("endLine", ValueConversions<int>::toValue(m_endLine));
+    result->setValue("endColumn", ValueConversions<int>::toValue(m_endColumn));
+    result->setValue("executionContextId", ValueConversions<int>::toValue(m_executionContextId));
+    result->setValue("hash", ValueConversions<String>::toValue(m_hash));
+    if (m_executionContextAuxData.isJust())
+        result->setValue("executionContextAuxData", ValueConversions<protocol::DictionaryValue>::toValue(m_executionContextAuxData.fromJust()));
+    if (m_isLiveEdit.isJust())
+        result->setValue("isLiveEdit", ValueConversions<bool>::toValue(m_isLiveEdit.fromJust()));
+    if (m_sourceMapURL.isJust())
+        result->setValue("sourceMapURL", ValueConversions<String>::toValue(m_sourceMapURL.fromJust()));
+    if (m_hasSourceURL.isJust())
+        result->setValue("hasSourceURL", ValueConversions<bool>::toValue(m_hasSourceURL.fromJust()));
+    return result;
+}
+
+std::unique_ptr<ScriptParsedNotification> ScriptParsedNotification::clone() const
+{
+    ErrorSupport errors;
+    return fromValue(toValue().get(), &errors);
+}
+
+std::unique_ptr<ScriptFailedToParseNotification> ScriptFailedToParseNotification::fromValue(protocol::Value* value, ErrorSupport* errors)
+{
+    if (!value || value->type() != protocol::Value::TypeObject) {
+        errors->addError("object expected");
+        return nullptr;
+    }
+
+    std::unique_ptr<ScriptFailedToParseNotification> result(new ScriptFailedToParseNotification());
+    protocol::DictionaryValue* object = DictionaryValue::cast(value);
+    errors->push();
+    protocol::Value* scriptIdValue = object->get("scriptId");
+    errors->setName("scriptId");
+    result->m_scriptId = ValueConversions<String>::fromValue(scriptIdValue, errors);
+    protocol::Value* urlValue = object->get("url");
+    errors->setName("url");
+    result->m_url = ValueConversions<String>::fromValue(urlValue, errors);
+    protocol::Value* startLineValue = object->get("startLine");
+    errors->setName("startLine");
+    result->m_startLine = ValueConversions<int>::fromValue(startLineValue, errors);
+    protocol::Value* startColumnValue = object->get("startColumn");
+    errors->setName("startColumn");
+    result->m_startColumn = ValueConversions<int>::fromValue(startColumnValue, errors);
+    protocol::Value* endLineValue = object->get("endLine");
+    errors->setName("endLine");
+    result->m_endLine = ValueConversions<int>::fromValue(endLineValue, errors);
+    protocol::Value* endColumnValue = object->get("endColumn");
+    errors->setName("endColumn");
+    result->m_endColumn = ValueConversions<int>::fromValue(endColumnValue, errors);
+    protocol::Value* executionContextIdValue = object->get("executionContextId");
+    errors->setName("executionContextId");
+    result->m_executionContextId = ValueConversions<int>::fromValue(executionContextIdValue, errors);
+    protocol::Value* hashValue = object->get("hash");
+    errors->setName("hash");
+    result->m_hash = ValueConversions<String>::fromValue(hashValue, errors);
+    protocol::Value* executionContextAuxDataValue = object->get("executionContextAuxData");
+    if (executionContextAuxDataValue) {
+        errors->setName("executionContextAuxData");
+        result->m_executionContextAuxData = ValueConversions<protocol::DictionaryValue>::fromValue(executionContextAuxDataValue, errors);
+    }
+    protocol::Value* sourceMapURLValue = object->get("sourceMapURL");
+    if (sourceMapURLValue) {
+        errors->setName("sourceMapURL");
+        result->m_sourceMapURL = ValueConversions<String>::fromValue(sourceMapURLValue, errors);
+    }
+    protocol::Value* hasSourceURLValue = object->get("hasSourceURL");
+    if (hasSourceURLValue) {
+        errors->setName("hasSourceURL");
+        result->m_hasSourceURL = ValueConversions<bool>::fromValue(hasSourceURLValue, errors);
+    }
+    errors->pop();
+    if (errors->hasErrors())
+        return nullptr;
+    return result;
+}
+
+std::unique_ptr<protocol::DictionaryValue> ScriptFailedToParseNotification::toValue() const
+{
+    std::unique_ptr<protocol::DictionaryValue> result = DictionaryValue::create();
+    result->setValue("scriptId", ValueConversions<String>::toValue(m_scriptId));
+    result->setValue("url", ValueConversions<String>::toValue(m_url));
+    result->setValue("startLine", ValueConversions<int>::toValue(m_startLine));
+    result->setValue("startColumn", ValueConversions<int>::toValue(m_startColumn));
+    result->setValue("endLine", ValueConversions<int>::toValue(m_endLine));
+    result->setValue("endColumn", ValueConversions<int>::toValue(m_endColumn));
+    result->setValue("executionContextId", ValueConversions<int>::toValue(m_executionContextId));
+    result->setValue("hash", ValueConversions<String>::toValue(m_hash));
+    if (m_executionContextAuxData.isJust())
+        result->setValue("executionContextAuxData", ValueConversions<protocol::DictionaryValue>::toValue(m_executionContextAuxData.fromJust()));
+    if (m_sourceMapURL.isJust())
+        result->setValue("sourceMapURL", ValueConversions<String>::toValue(m_sourceMapURL.fromJust()));
+    if (m_hasSourceURL.isJust())
+        result->setValue("hasSourceURL", ValueConversions<bool>::toValue(m_hasSourceURL.fromJust()));
+    return result;
+}
+
+std::unique_ptr<ScriptFailedToParseNotification> ScriptFailedToParseNotification::clone() const
+{
+    ErrorSupport errors;
+    return fromValue(toValue().get(), &errors);
+}
+
+std::unique_ptr<BreakpointResolvedNotification> BreakpointResolvedNotification::fromValue(protocol::Value* value, ErrorSupport* errors)
+{
+    if (!value || value->type() != protocol::Value::TypeObject) {
+        errors->addError("object expected");
+        return nullptr;
+    }
+
+    std::unique_ptr<BreakpointResolvedNotification> result(new BreakpointResolvedNotification());
+    protocol::DictionaryValue* object = DictionaryValue::cast(value);
+    errors->push();
+    protocol::Value* breakpointIdValue = object->get("breakpointId");
+    errors->setName("breakpointId");
+    result->m_breakpointId = ValueConversions<String>::fromValue(breakpointIdValue, errors);
+    protocol::Value* locationValue = object->get("location");
+    errors->setName("location");
+    result->m_location = ValueConversions<protocol::Debugger::Location>::fromValue(locationValue, errors);
+    errors->pop();
+    if (errors->hasErrors())
+        return nullptr;
+    return result;
+}
+
+std::unique_ptr<protocol::DictionaryValue> BreakpointResolvedNotification::toValue() const
+{
+    std::unique_ptr<protocol::DictionaryValue> result = DictionaryValue::create();
+    result->setValue("breakpointId", ValueConversions<String>::toValue(m_breakpointId));
+    result->setValue("location", ValueConversions<protocol::Debugger::Location>::toValue(m_location.get()));
+    return result;
+}
+
+std::unique_ptr<BreakpointResolvedNotification> BreakpointResolvedNotification::clone() const
+{
+    ErrorSupport errors;
+    return fromValue(toValue().get(), &errors);
+}
+
+const char* PausedNotification::ReasonEnum::XHR = "XHR";
+const char* PausedNotification::ReasonEnum::DOM = "DOM";
+const char* PausedNotification::ReasonEnum::EventListener = "EventListener";
+const char* PausedNotification::ReasonEnum::Exception = "exception";
+const char* PausedNotification::ReasonEnum::Assert = "assert";
+const char* PausedNotification::ReasonEnum::DebugCommand = "debugCommand";
+const char* PausedNotification::ReasonEnum::PromiseRejection = "promiseRejection";
+const char* PausedNotification::ReasonEnum::Other = "other";
+
+std::unique_ptr<PausedNotification> PausedNotification::fromValue(protocol::Value* value, ErrorSupport* errors)
+{
+    if (!value || value->type() != protocol::Value::TypeObject) {
+        errors->addError("object expected");
+        return nullptr;
+    }
+
+    std::unique_ptr<PausedNotification> result(new PausedNotification());
+    protocol::DictionaryValue* object = DictionaryValue::cast(value);
+    errors->push();
+    protocol::Value* callFramesValue = object->get("callFrames");
+    errors->setName("callFrames");
+    result->m_callFrames = ValueConversions<protocol::Array<protocol::Debugger::CallFrame>>::fromValue(callFramesValue, errors);
+    protocol::Value* reasonValue = object->get("reason");
+    errors->setName("reason");
+    result->m_reason = ValueConversions<String>::fromValue(reasonValue, errors);
+    protocol::Value* dataValue = object->get("data");
+    if (dataValue) {
+        errors->setName("data");
+        result->m_data = ValueConversions<protocol::DictionaryValue>::fromValue(dataValue, errors);
+    }
+    protocol::Value* hitBreakpointsValue = object->get("hitBreakpoints");
+    if (hitBreakpointsValue) {
+        errors->setName("hitBreakpoints");
+        result->m_hitBreakpoints = ValueConversions<protocol::Array<String>>::fromValue(hitBreakpointsValue, errors);
+    }
+    protocol::Value* asyncStackTraceValue = object->get("asyncStackTrace");
+    if (asyncStackTraceValue) {
+        errors->setName("asyncStackTrace");
+        result->m_asyncStackTrace = ValueConversions<protocol::Runtime::StackTrace>::fromValue(asyncStackTraceValue, errors);
+    }
+    errors->pop();
+    if (errors->hasErrors())
+        return nullptr;
+    return result;
+}
+
+std::unique_ptr<protocol::DictionaryValue> PausedNotification::toValue() const
+{
+    std::unique_ptr<protocol::DictionaryValue> result = DictionaryValue::create();
+    result->setValue("callFrames", ValueConversions<protocol::Array<protocol::Debugger::CallFrame>>::toValue(m_callFrames.get()));
+    result->setValue("reason", ValueConversions<String>::toValue(m_reason));
+    if (m_data.isJust())
+        result->setValue("data", ValueConversions<protocol::DictionaryValue>::toValue(m_data.fromJust()));
+    if (m_hitBreakpoints.isJust())
+        result->setValue("hitBreakpoints", ValueConversions<protocol::Array<String>>::toValue(m_hitBreakpoints.fromJust()));
+    if (m_asyncStackTrace.isJust())
+        result->setValue("asyncStackTrace", ValueConversions<protocol::Runtime::StackTrace>::toValue(m_asyncStackTrace.fromJust()));
+    return result;
+}
+
+std::unique_ptr<PausedNotification> PausedNotification::clone() const
+{
+    ErrorSupport errors;
+    return fromValue(toValue().get(), &errors);
+}
+
+// ------------- Enum values from params.
+
+
+namespace SetPauseOnExceptions {
+namespace StateEnum {
+const char* None = "none";
+const char* Uncaught = "uncaught";
+const char* All = "all";
+} // namespace StateEnum
+} // namespace SetPauseOnExceptions
+
+namespace Paused {
+namespace ReasonEnum {
+const char* XHR = "XHR";
+const char* DOM = "DOM";
+const char* EventListener = "EventListener";
+const char* Exception = "exception";
+const char* Assert = "assert";
+const char* DebugCommand = "debugCommand";
+const char* PromiseRejection = "promiseRejection";
+const char* Other = "other";
+} // namespace ReasonEnum
+} // namespace Paused
+
+namespace API {
+namespace Paused {
+namespace ReasonEnum {
+const char* XHR = "XHR";
+const char* DOM = "DOM";
+const char* EventListener = "EventListener";
+const char* Exception = "exception";
+const char* Assert = "assert";
+const char* DebugCommand = "debugCommand";
+const char* PromiseRejection = "promiseRejection";
+const char* Other = "other";
+} // namespace ReasonEnum
+} // namespace Paused
+} // namespace API
+
+// ------------- Frontend notifications.
+
+void Frontend::scriptParsed(const String& scriptId, const String& url, int startLine, int startColumn, int endLine, int endColumn, int executionContextId, const String& hash, Maybe<protocol::DictionaryValue> executionContextAuxData, Maybe<bool> isLiveEdit, Maybe<String> sourceMapURL, Maybe<bool> hasSourceURL)
+{
+    if (!m_frontendChannel)
+        return;
+    std::unique_ptr<ScriptParsedNotification> messageData = ScriptParsedNotification::create()
+        .setScriptId(scriptId)
+        .setUrl(url)
+        .setStartLine(startLine)
+        .setStartColumn(startColumn)
+        .setEndLine(endLine)
+        .setEndColumn(endColumn)
+        .setExecutionContextId(executionContextId)
+        .setHash(hash)
+        .build();
+    if (executionContextAuxData.isJust())
+        messageData->setExecutionContextAuxData(std::move(executionContextAuxData).takeJust());
+    if (isLiveEdit.isJust())
+        messageData->setIsLiveEdit(std::move(isLiveEdit).takeJust());
+    if (sourceMapURL.isJust())
+        messageData->setSourceMapURL(std::move(sourceMapURL).takeJust());
+    if (hasSourceURL.isJust())
+        messageData->setHasSourceURL(std::move(hasSourceURL).takeJust());
+    m_frontendChannel->sendProtocolNotification(InternalResponse::createNotification("Debugger.scriptParsed", std::move(messageData)));
+}
+
+void Frontend::scriptFailedToParse(const String& scriptId, const String& url, int startLine, int startColumn, int endLine, int endColumn, int executionContextId, const String& hash, Maybe<protocol::DictionaryValue> executionContextAuxData, Maybe<String> sourceMapURL, Maybe<bool> hasSourceURL)
+{
+    if (!m_frontendChannel)
+        return;
+    std::unique_ptr<ScriptFailedToParseNotification> messageData = ScriptFailedToParseNotification::create()
+        .setScriptId(scriptId)
+        .setUrl(url)
+        .setStartLine(startLine)
+        .setStartColumn(startColumn)
+        .setEndLine(endLine)
+        .setEndColumn(endColumn)
+        .setExecutionContextId(executionContextId)
+        .setHash(hash)
+        .build();
+    if (executionContextAuxData.isJust())
+        messageData->setExecutionContextAuxData(std::move(executionContextAuxData).takeJust());
+    if (sourceMapURL.isJust())
+        messageData->setSourceMapURL(std::move(sourceMapURL).takeJust());
+    if (hasSourceURL.isJust())
+        messageData->setHasSourceURL(std::move(hasSourceURL).takeJust());
+    m_frontendChannel->sendProtocolNotification(InternalResponse::createNotification("Debugger.scriptFailedToParse", std::move(messageData)));
+}
+
+void Frontend::breakpointResolved(const String& breakpointId, std::unique_ptr<protocol::Debugger::Location> location)
+{
+    if (!m_frontendChannel)
+        return;
+    std::unique_ptr<BreakpointResolvedNotification> messageData = BreakpointResolvedNotification::create()
+        .setBreakpointId(breakpointId)
+        .setLocation(std::move(location))
+        .build();
+    m_frontendChannel->sendProtocolNotification(InternalResponse::createNotification("Debugger.breakpointResolved", std::move(messageData)));
+}
+
+void Frontend::paused(std::unique_ptr<protocol::Array<protocol::Debugger::CallFrame>> callFrames, const String& reason, Maybe<protocol::DictionaryValue> data, Maybe<protocol::Array<String>> hitBreakpoints, Maybe<protocol::Runtime::StackTrace> asyncStackTrace)
+{
+    if (!m_frontendChannel)
+        return;
+    std::unique_ptr<PausedNotification> messageData = PausedNotification::create()
+        .setCallFrames(std::move(callFrames))
+        .setReason(reason)
+        .build();
+    if (data.isJust())
+        messageData->setData(std::move(data).takeJust());
+    if (hitBreakpoints.isJust())
+        messageData->setHitBreakpoints(std::move(hitBreakpoints).takeJust());
+    if (asyncStackTrace.isJust())
+        messageData->setAsyncStackTrace(std::move(asyncStackTrace).takeJust());
+    m_frontendChannel->sendProtocolNotification(InternalResponse::createNotification("Debugger.paused", std::move(messageData)));
+}
+
+void Frontend::resumed()
+{
+    if (!m_frontendChannel)
+        return;
+    m_frontendChannel->sendProtocolNotification(InternalResponse::createNotification("Debugger.resumed"));
+}
+
+void Frontend::flush()
+{
+    m_frontendChannel->flushProtocolNotifications();
+}
+
+void Frontend::sendRawNotification(const String& notification)
+{
+    m_frontendChannel->sendProtocolNotification(InternalRawNotification::create(notification));
+}
+
+// --------------------- Dispatcher.
+
+class DispatcherImpl : public protocol::DispatcherBase {
+public:
+    DispatcherImpl(FrontendChannel* frontendChannel, Backend* backend, bool fallThroughForNotFound)
+        : DispatcherBase(frontendChannel)
+        , m_backend(backend)
+        , m_fallThroughForNotFound(fallThroughForNotFound) {
+        m_dispatchMap["Debugger.enable"] = &DispatcherImpl::enable;
+        m_dispatchMap["Debugger.disable"] = &DispatcherImpl::disable;
+        m_dispatchMap["Debugger.setBreakpointsActive"] = &DispatcherImpl::setBreakpointsActive;
+        m_dispatchMap["Debugger.setSkipAllPauses"] = &DispatcherImpl::setSkipAllPauses;
+        m_dispatchMap["Debugger.setBreakpointByUrl"] = &DispatcherImpl::setBreakpointByUrl;
+        m_dispatchMap["Debugger.setBreakpoint"] = &DispatcherImpl::setBreakpoint;
+        m_dispatchMap["Debugger.removeBreakpoint"] = &DispatcherImpl::removeBreakpoint;
+        m_dispatchMap["Debugger.continueToLocation"] = &DispatcherImpl::continueToLocation;
+        m_dispatchMap["Debugger.stepOver"] = &DispatcherImpl::stepOver;
+        m_dispatchMap["Debugger.stepInto"] = &DispatcherImpl::stepInto;
+        m_dispatchMap["Debugger.stepOut"] = &DispatcherImpl::stepOut;
+        m_dispatchMap["Debugger.pause"] = &DispatcherImpl::pause;
+        m_dispatchMap["Debugger.resume"] = &DispatcherImpl::resume;
+        m_dispatchMap["Debugger.searchInContent"] = &DispatcherImpl::searchInContent;
+        m_dispatchMap["Debugger.setScriptSource"] = &DispatcherImpl::setScriptSource;
+        m_dispatchMap["Debugger.restartFrame"] = &DispatcherImpl::restartFrame;
+        m_dispatchMap["Debugger.getScriptSource"] = &DispatcherImpl::getScriptSource;
+        m_dispatchMap["Debugger.setPauseOnExceptions"] = &DispatcherImpl::setPauseOnExceptions;
+        m_dispatchMap["Debugger.evaluateOnCallFrame"] = &DispatcherImpl::evaluateOnCallFrame;
+        m_dispatchMap["Debugger.setVariableValue"] = &DispatcherImpl::setVariableValue;
+        m_dispatchMap["Debugger.setAsyncCallStackDepth"] = &DispatcherImpl::setAsyncCallStackDepth;
+        m_dispatchMap["Debugger.setBlackboxPatterns"] = &DispatcherImpl::setBlackboxPatterns;
+        m_dispatchMap["Debugger.setBlackboxedRanges"] = &DispatcherImpl::setBlackboxedRanges;
+    }
+    ~DispatcherImpl() override { }
+    DispatchResponse::Status dispatch(int callId, const String& method, std::unique_ptr<protocol::DictionaryValue> messageObject) override;
+    HashMap<String, String>& redirects() { return m_redirects; }
+
+protected:
+    using CallHandler = DispatchResponse::Status (DispatcherImpl::*)(int callId, std::unique_ptr<DictionaryValue> messageObject, ErrorSupport* errors);
+    using DispatchMap = protocol::HashMap<String, CallHandler>;
+    DispatchMap m_dispatchMap;
+    HashMap<String, String> m_redirects;
+
+    DispatchResponse::Status enable(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport*);
+    DispatchResponse::Status disable(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport*);
+    DispatchResponse::Status setBreakpointsActive(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport*);
+    DispatchResponse::Status setSkipAllPauses(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport*);
+    DispatchResponse::Status setBreakpointByUrl(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport*);
+    DispatchResponse::Status setBreakpoint(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport*);
+    DispatchResponse::Status removeBreakpoint(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport*);
+    DispatchResponse::Status continueToLocation(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport*);
+    DispatchResponse::Status stepOver(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport*);
+    DispatchResponse::Status stepInto(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport*);
+    DispatchResponse::Status stepOut(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport*);
+    DispatchResponse::Status pause(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport*);
+    DispatchResponse::Status resume(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport*);
+    DispatchResponse::Status searchInContent(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport*);
+    DispatchResponse::Status setScriptSource(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport*);
+    DispatchResponse::Status restartFrame(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport*);
+    DispatchResponse::Status getScriptSource(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport*);
+    DispatchResponse::Status setPauseOnExceptions(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport*);
+    DispatchResponse::Status evaluateOnCallFrame(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport*);
+    DispatchResponse::Status setVariableValue(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport*);
+    DispatchResponse::Status setAsyncCallStackDepth(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport*);
+    DispatchResponse::Status setBlackboxPatterns(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport*);
+    DispatchResponse::Status setBlackboxedRanges(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport*);
+
+    Backend* m_backend;
+    bool m_fallThroughForNotFound;
+};
+
+DispatchResponse::Status DispatcherImpl::dispatch(int callId, const String& method, std::unique_ptr<protocol::DictionaryValue> messageObject)
+{
+    protocol::HashMap<String, CallHandler>::iterator it = m_dispatchMap.find(method);
+    if (it == m_dispatchMap.end()) {
+        if (m_fallThroughForNotFound)
+            return DispatchResponse::kFallThrough;
+        reportProtocolError(callId, DispatchResponse::kMethodNotFound, "'" + method + "' wasn't found", nullptr);
+        return DispatchResponse::kError;
+    }
+
+    protocol::ErrorSupport errors;
+    return (this->*(it->second))(callId, std::move(messageObject), &errors);
+}
+
+
+DispatchResponse::Status DispatcherImpl::enable(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport* errors)
+{
+
+    std::unique_ptr<DispatcherBase::WeakPtr> weak = weakPtr();
+    DispatchResponse response = m_backend->enable();
+    if (response.status() == DispatchResponse::kFallThrough)
+        return response.status();
+    if (weak->get())
+        weak->get()->sendResponse(callId, response);
+    return response.status();
+}
+
+DispatchResponse::Status DispatcherImpl::disable(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport* errors)
+{
+
+    std::unique_ptr<DispatcherBase::WeakPtr> weak = weakPtr();
+    DispatchResponse response = m_backend->disable();
+    if (response.status() == DispatchResponse::kFallThrough)
+        return response.status();
+    if (weak->get())
+        weak->get()->sendResponse(callId, response);
+    return response.status();
+}
+
+DispatchResponse::Status DispatcherImpl::setBreakpointsActive(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport* errors)
+{
+    // Prepare input parameters.
+    protocol::DictionaryValue* object = DictionaryValue::cast(requestMessageObject->get("params"));
+    errors->push();
+    protocol::Value* activeValue = object ? object->get("active") : nullptr;
+    errors->setName("active");
+    bool in_active = ValueConversions<bool>::fromValue(activeValue, errors);
+    errors->pop();
+    if (errors->hasErrors()) {
+        reportProtocolError(callId, DispatchResponse::kInvalidParams, kInvalidParamsString, errors);
+        return DispatchResponse::kError;
+    }
+
+    std::unique_ptr<DispatcherBase::WeakPtr> weak = weakPtr();
+    DispatchResponse response = m_backend->setBreakpointsActive(in_active);
+    if (response.status() == DispatchResponse::kFallThrough)
+        return response.status();
+    if (weak->get())
+        weak->get()->sendResponse(callId, response);
+    return response.status();
+}
+
+DispatchResponse::Status DispatcherImpl::setSkipAllPauses(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport* errors)
+{
+    // Prepare input parameters.
+    protocol::DictionaryValue* object = DictionaryValue::cast(requestMessageObject->get("params"));
+    errors->push();
+    protocol::Value* skipValue = object ? object->get("skip") : nullptr;
+    errors->setName("skip");
+    bool in_skip = ValueConversions<bool>::fromValue(skipValue, errors);
+    errors->pop();
+    if (errors->hasErrors()) {
+        reportProtocolError(callId, DispatchResponse::kInvalidParams, kInvalidParamsString, errors);
+        return DispatchResponse::kError;
+    }
+
+    std::unique_ptr<DispatcherBase::WeakPtr> weak = weakPtr();
+    DispatchResponse response = m_backend->setSkipAllPauses(in_skip);
+    if (response.status() == DispatchResponse::kFallThrough)
+        return response.status();
+    if (weak->get())
+        weak->get()->sendResponse(callId, response);
+    return response.status();
+}
+
+DispatchResponse::Status DispatcherImpl::setBreakpointByUrl(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport* errors)
+{
+    // Prepare input parameters.
+    protocol::DictionaryValue* object = DictionaryValue::cast(requestMessageObject->get("params"));
+    errors->push();
+    protocol::Value* lineNumberValue = object ? object->get("lineNumber") : nullptr;
+    errors->setName("lineNumber");
+    int in_lineNumber = ValueConversions<int>::fromValue(lineNumberValue, errors);
+    protocol::Value* urlValue = object ? object->get("url") : nullptr;
+    Maybe<String> in_url;
+    if (urlValue) {
+        errors->setName("url");
+        in_url = ValueConversions<String>::fromValue(urlValue, errors);
+    }
+    protocol::Value* urlRegexValue = object ? object->get("urlRegex") : nullptr;
+    Maybe<String> in_urlRegex;
+    if (urlRegexValue) {
+        errors->setName("urlRegex");
+        in_urlRegex = ValueConversions<String>::fromValue(urlRegexValue, errors);
+    }
+    protocol::Value* columnNumberValue = object ? object->get("columnNumber") : nullptr;
+    Maybe<int> in_columnNumber;
+    if (columnNumberValue) {
+        errors->setName("columnNumber");
+        in_columnNumber = ValueConversions<int>::fromValue(columnNumberValue, errors);
+    }
+    protocol::Value* conditionValue = object ? object->get("condition") : nullptr;
+    Maybe<String> in_condition;
+    if (conditionValue) {
+        errors->setName("condition");
+        in_condition = ValueConversions<String>::fromValue(conditionValue, errors);
+    }
+    errors->pop();
+    if (errors->hasErrors()) {
+        reportProtocolError(callId, DispatchResponse::kInvalidParams, kInvalidParamsString, errors);
+        return DispatchResponse::kError;
+    }
+    // Declare output parameters.
+    String out_breakpointId;
+    std::unique_ptr<protocol::Array<protocol::Debugger::Location>> out_locations;
+
+    std::unique_ptr<DispatcherBase::WeakPtr> weak = weakPtr();
+    DispatchResponse response = m_backend->setBreakpointByUrl(in_lineNumber, std::move(in_url), std::move(in_urlRegex), std::move(in_columnNumber), std::move(in_condition), &out_breakpointId, &out_locations);
+    if (response.status() == DispatchResponse::kFallThrough)
+        return response.status();
+    std::unique_ptr<protocol::DictionaryValue> result = DictionaryValue::create();
+    if (response.status() == DispatchResponse::kSuccess) {
+        result->setValue("breakpointId", ValueConversions<String>::toValue(out_breakpointId));
+        result->setValue("locations", ValueConversions<protocol::Array<protocol::Debugger::Location>>::toValue(out_locations.get()));
+    }
+    if (weak->get())
+        weak->get()->sendResponse(callId, response, std::move(result));
+    return response.status();
+}
+
+DispatchResponse::Status DispatcherImpl::setBreakpoint(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport* errors)
+{
+    // Prepare input parameters.
+    protocol::DictionaryValue* object = DictionaryValue::cast(requestMessageObject->get("params"));
+    errors->push();
+    protocol::Value* locationValue = object ? object->get("location") : nullptr;
+    errors->setName("location");
+    std::unique_ptr<protocol::Debugger::Location> in_location = ValueConversions<protocol::Debugger::Location>::fromValue(locationValue, errors);
+    protocol::Value* conditionValue = object ? object->get("condition") : nullptr;
+    Maybe<String> in_condition;
+    if (conditionValue) {
+        errors->setName("condition");
+        in_condition = ValueConversions<String>::fromValue(conditionValue, errors);
+    }
+    errors->pop();
+    if (errors->hasErrors()) {
+        reportProtocolError(callId, DispatchResponse::kInvalidParams, kInvalidParamsString, errors);
+        return DispatchResponse::kError;
+    }
+    // Declare output parameters.
+    String out_breakpointId;
+    std::unique_ptr<protocol::Debugger::Location> out_actualLocation;
+
+    std::unique_ptr<DispatcherBase::WeakPtr> weak = weakPtr();
+    DispatchResponse response = m_backend->setBreakpoint(std::move(in_location), std::move(in_condition), &out_breakpointId, &out_actualLocation);
+    if (response.status() == DispatchResponse::kFallThrough)
+        return response.status();
+    std::unique_ptr<protocol::DictionaryValue> result = DictionaryValue::create();
+    if (response.status() == DispatchResponse::kSuccess) {
+        result->setValue("breakpointId", ValueConversions<String>::toValue(out_breakpointId));
+        result->setValue("actualLocation", ValueConversions<protocol::Debugger::Location>::toValue(out_actualLocation.get()));
+    }
+    if (weak->get())
+        weak->get()->sendResponse(callId, response, std::move(result));
+    return response.status();
+}
+
+DispatchResponse::Status DispatcherImpl::removeBreakpoint(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport* errors)
+{
+    // Prepare input parameters.
+    protocol::DictionaryValue* object = DictionaryValue::cast(requestMessageObject->get("params"));
+    errors->push();
+    protocol::Value* breakpointIdValue = object ? object->get("breakpointId") : nullptr;
+    errors->setName("breakpointId");
+    String in_breakpointId = ValueConversions<String>::fromValue(breakpointIdValue, errors);
+    errors->pop();
+    if (errors->hasErrors()) {
+        reportProtocolError(callId, DispatchResponse::kInvalidParams, kInvalidParamsString, errors);
+        return DispatchResponse::kError;
+    }
+
+    std::unique_ptr<DispatcherBase::WeakPtr> weak = weakPtr();
+    DispatchResponse response = m_backend->removeBreakpoint(in_breakpointId);
+    if (response.status() == DispatchResponse::kFallThrough)
+        return response.status();
+    if (weak->get())
+        weak->get()->sendResponse(callId, response);
+    return response.status();
+}
+
+DispatchResponse::Status DispatcherImpl::continueToLocation(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport* errors)
+{
+    // Prepare input parameters.
+    protocol::DictionaryValue* object = DictionaryValue::cast(requestMessageObject->get("params"));
+    errors->push();
+    protocol::Value* locationValue = object ? object->get("location") : nullptr;
+    errors->setName("location");
+    std::unique_ptr<protocol::Debugger::Location> in_location = ValueConversions<protocol::Debugger::Location>::fromValue(locationValue, errors);
+    errors->pop();
+    if (errors->hasErrors()) {
+        reportProtocolError(callId, DispatchResponse::kInvalidParams, kInvalidParamsString, errors);
+        return DispatchResponse::kError;
+    }
+
+    std::unique_ptr<DispatcherBase::WeakPtr> weak = weakPtr();
+    DispatchResponse response = m_backend->continueToLocation(std::move(in_location));
+    if (response.status() == DispatchResponse::kFallThrough)
+        return response.status();
+    if (weak->get())
+        weak->get()->sendResponse(callId, response);
+    return response.status();
+}
+
+DispatchResponse::Status DispatcherImpl::stepOver(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport* errors)
+{
+
+    std::unique_ptr<DispatcherBase::WeakPtr> weak = weakPtr();
+    DispatchResponse response = m_backend->stepOver();
+    if (response.status() == DispatchResponse::kFallThrough)
+        return response.status();
+    if (weak->get())
+        weak->get()->sendResponse(callId, response);
+    return response.status();
+}
+
+DispatchResponse::Status DispatcherImpl::stepInto(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport* errors)
+{
+
+    std::unique_ptr<DispatcherBase::WeakPtr> weak = weakPtr();
+    DispatchResponse response = m_backend->stepInto();
+    if (response.status() == DispatchResponse::kFallThrough)
+        return response.status();
+    if (weak->get())
+        weak->get()->sendResponse(callId, response);
+    return response.status();
+}
+
+DispatchResponse::Status DispatcherImpl::stepOut(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport* errors)
+{
+
+    std::unique_ptr<DispatcherBase::WeakPtr> weak = weakPtr();
+    DispatchResponse response = m_backend->stepOut();
+    if (response.status() == DispatchResponse::kFallThrough)
+        return response.status();
+    if (weak->get())
+        weak->get()->sendResponse(callId, response);
+    return response.status();
+}
+
+DispatchResponse::Status DispatcherImpl::pause(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport* errors)
+{
+
+    std::unique_ptr<DispatcherBase::WeakPtr> weak = weakPtr();
+    DispatchResponse response = m_backend->pause();
+    if (response.status() == DispatchResponse::kFallThrough)
+        return response.status();
+    if (weak->get())
+        weak->get()->sendResponse(callId, response);
+    return response.status();
+}
+
+DispatchResponse::Status DispatcherImpl::resume(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport* errors)
+{
+
+    std::unique_ptr<DispatcherBase::WeakPtr> weak = weakPtr();
+    DispatchResponse response = m_backend->resume();
+    if (response.status() == DispatchResponse::kFallThrough)
+        return response.status();
+    if (weak->get())
+        weak->get()->sendResponse(callId, response);
+    return response.status();
+}
+
+DispatchResponse::Status DispatcherImpl::searchInContent(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport* errors)
+{
+    // Prepare input parameters.
+    protocol::DictionaryValue* object = DictionaryValue::cast(requestMessageObject->get("params"));
+    errors->push();
+    protocol::Value* scriptIdValue = object ? object->get("scriptId") : nullptr;
+    errors->setName("scriptId");
+    String in_scriptId = ValueConversions<String>::fromValue(scriptIdValue, errors);
+    protocol::Value* queryValue = object ? object->get("query") : nullptr;
+    errors->setName("query");
+    String in_query = ValueConversions<String>::fromValue(queryValue, errors);
+    protocol::Value* caseSensitiveValue = object ? object->get("caseSensitive") : nullptr;
+    Maybe<bool> in_caseSensitive;
+    if (caseSensitiveValue) {
+        errors->setName("caseSensitive");
+        in_caseSensitive = ValueConversions<bool>::fromValue(caseSensitiveValue, errors);
+    }
+    protocol::Value* isRegexValue = object ? object->get("isRegex") : nullptr;
+    Maybe<bool> in_isRegex;
+    if (isRegexValue) {
+        errors->setName("isRegex");
+        in_isRegex = ValueConversions<bool>::fromValue(isRegexValue, errors);
+    }
+    errors->pop();
+    if (errors->hasErrors()) {
+        reportProtocolError(callId, DispatchResponse::kInvalidParams, kInvalidParamsString, errors);
+        return DispatchResponse::kError;
+    }
+    // Declare output parameters.
+    std::unique_ptr<protocol::Array<protocol::Debugger::SearchMatch>> out_result;
+
+    std::unique_ptr<DispatcherBase::WeakPtr> weak = weakPtr();
+    DispatchResponse response = m_backend->searchInContent(in_scriptId, in_query, std::move(in_caseSensitive), std::move(in_isRegex), &out_result);
+    if (response.status() == DispatchResponse::kFallThrough)
+        return response.status();
+    std::unique_ptr<protocol::DictionaryValue> result = DictionaryValue::create();
+    if (response.status() == DispatchResponse::kSuccess) {
+        result->setValue("result", ValueConversions<protocol::Array<protocol::Debugger::SearchMatch>>::toValue(out_result.get()));
+    }
+    if (weak->get())
+        weak->get()->sendResponse(callId, response, std::move(result));
+    return response.status();
+}
+
+DispatchResponse::Status DispatcherImpl::setScriptSource(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport* errors)
+{
+    // Prepare input parameters.
+    protocol::DictionaryValue* object = DictionaryValue::cast(requestMessageObject->get("params"));
+    errors->push();
+    protocol::Value* scriptIdValue = object ? object->get("scriptId") : nullptr;
+    errors->setName("scriptId");
+    String in_scriptId = ValueConversions<String>::fromValue(scriptIdValue, errors);
+    protocol::Value* scriptSourceValue = object ? object->get("scriptSource") : nullptr;
+    errors->setName("scriptSource");
+    String in_scriptSource = ValueConversions<String>::fromValue(scriptSourceValue, errors);
+    protocol::Value* dryRunValue = object ? object->get("dryRun") : nullptr;
+    Maybe<bool> in_dryRun;
+    if (dryRunValue) {
+        errors->setName("dryRun");
+        in_dryRun = ValueConversions<bool>::fromValue(dryRunValue, errors);
+    }
+    errors->pop();
+    if (errors->hasErrors()) {
+        reportProtocolError(callId, DispatchResponse::kInvalidParams, kInvalidParamsString, errors);
+        return DispatchResponse::kError;
+    }
+    // Declare output parameters.
+    Maybe<protocol::Array<protocol::Debugger::CallFrame>> out_callFrames;
+    Maybe<bool> out_stackChanged;
+    Maybe<protocol::Runtime::StackTrace> out_asyncStackTrace;
+    Maybe<protocol::Runtime::ExceptionDetails> out_exceptionDetails;
+
+    std::unique_ptr<DispatcherBase::WeakPtr> weak = weakPtr();
+    DispatchResponse response = m_backend->setScriptSource(in_scriptId, in_scriptSource, std::move(in_dryRun), &out_callFrames, &out_stackChanged, &out_asyncStackTrace, &out_exceptionDetails);
+    if (response.status() == DispatchResponse::kFallThrough)
+        return response.status();
+    std::unique_ptr<protocol::DictionaryValue> result = DictionaryValue::create();
+    if (response.status() == DispatchResponse::kSuccess) {
+        if (out_callFrames.isJust())
+            result->setValue("callFrames", ValueConversions<protocol::Array<protocol::Debugger::CallFrame>>::toValue(out_callFrames.fromJust()));
+        if (out_stackChanged.isJust())
+            result->setValue("stackChanged", ValueConversions<bool>::toValue(out_stackChanged.fromJust()));
+        if (out_asyncStackTrace.isJust())
+            result->setValue("asyncStackTrace", ValueConversions<protocol::Runtime::StackTrace>::toValue(out_asyncStackTrace.fromJust()));
+        if (out_exceptionDetails.isJust())
+            result->setValue("exceptionDetails", ValueConversions<protocol::Runtime::ExceptionDetails>::toValue(out_exceptionDetails.fromJust()));
+    }
+    if (weak->get())
+        weak->get()->sendResponse(callId, response, std::move(result));
+    return response.status();
+}
+
+DispatchResponse::Status DispatcherImpl::restartFrame(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport* errors)
+{
+    // Prepare input parameters.
+    protocol::DictionaryValue* object = DictionaryValue::cast(requestMessageObject->get("params"));
+    errors->push();
+    protocol::Value* callFrameIdValue = object ? object->get("callFrameId") : nullptr;
+    errors->setName("callFrameId");
+    String in_callFrameId = ValueConversions<String>::fromValue(callFrameIdValue, errors);
+    errors->pop();
+    if (errors->hasErrors()) {
+        reportProtocolError(callId, DispatchResponse::kInvalidParams, kInvalidParamsString, errors);
+        return DispatchResponse::kError;
+    }
+    // Declare output parameters.
+    std::unique_ptr<protocol::Array<protocol::Debugger::CallFrame>> out_callFrames;
+    Maybe<protocol::Runtime::StackTrace> out_asyncStackTrace;
+
+    std::unique_ptr<DispatcherBase::WeakPtr> weak = weakPtr();
+    DispatchResponse response = m_backend->restartFrame(in_callFrameId, &out_callFrames, &out_asyncStackTrace);
+    if (response.status() == DispatchResponse::kFallThrough)
+        return response.status();
+    std::unique_ptr<protocol::DictionaryValue> result = DictionaryValue::create();
+    if (response.status() == DispatchResponse::kSuccess) {
+        result->setValue("callFrames", ValueConversions<protocol::Array<protocol::Debugger::CallFrame>>::toValue(out_callFrames.get()));
+        if (out_asyncStackTrace.isJust())
+            result->setValue("asyncStackTrace", ValueConversions<protocol::Runtime::StackTrace>::toValue(out_asyncStackTrace.fromJust()));
+    }
+    if (weak->get())
+        weak->get()->sendResponse(callId, response, std::move(result));
+    return response.status();
+}
+
+DispatchResponse::Status DispatcherImpl::getScriptSource(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport* errors)
+{
+    // Prepare input parameters.
+    protocol::DictionaryValue* object = DictionaryValue::cast(requestMessageObject->get("params"));
+    errors->push();
+    protocol::Value* scriptIdValue = object ? object->get("scriptId") : nullptr;
+    errors->setName("scriptId");
+    String in_scriptId = ValueConversions<String>::fromValue(scriptIdValue, errors);
+    errors->pop();
+    if (errors->hasErrors()) {
+        reportProtocolError(callId, DispatchResponse::kInvalidParams, kInvalidParamsString, errors);
+        return DispatchResponse::kError;
+    }
+    // Declare output parameters.
+    String out_scriptSource;
+
+    std::unique_ptr<DispatcherBase::WeakPtr> weak = weakPtr();
+    DispatchResponse response = m_backend->getScriptSource(in_scriptId, &out_scriptSource);
+    if (response.status() == DispatchResponse::kFallThrough)
+        return response.status();
+    std::unique_ptr<protocol::DictionaryValue> result = DictionaryValue::create();
+    if (response.status() == DispatchResponse::kSuccess) {
+        result->setValue("scriptSource", ValueConversions<String>::toValue(out_scriptSource));
+    }
+    if (weak->get())
+        weak->get()->sendResponse(callId, response, std::move(result));
+    return response.status();
+}
+
+DispatchResponse::Status DispatcherImpl::setPauseOnExceptions(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport* errors)
+{
+    // Prepare input parameters.
+    protocol::DictionaryValue* object = DictionaryValue::cast(requestMessageObject->get("params"));
+    errors->push();
+    protocol::Value* stateValue = object ? object->get("state") : nullptr;
+    errors->setName("state");
+    String in_state = ValueConversions<String>::fromValue(stateValue, errors);
+    errors->pop();
+    if (errors->hasErrors()) {
+        reportProtocolError(callId, DispatchResponse::kInvalidParams, kInvalidParamsString, errors);
+        return DispatchResponse::kError;
+    }
+
+    std::unique_ptr<DispatcherBase::WeakPtr> weak = weakPtr();
+    DispatchResponse response = m_backend->setPauseOnExceptions(in_state);
+    if (response.status() == DispatchResponse::kFallThrough)
+        return response.status();
+    if (weak->get())
+        weak->get()->sendResponse(callId, response);
+    return response.status();
+}
+
+DispatchResponse::Status DispatcherImpl::evaluateOnCallFrame(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport* errors)
+{
+    // Prepare input parameters.
+    protocol::DictionaryValue* object = DictionaryValue::cast(requestMessageObject->get("params"));
+    errors->push();
+    protocol::Value* callFrameIdValue = object ? object->get("callFrameId") : nullptr;
+    errors->setName("callFrameId");
+    String in_callFrameId = ValueConversions<String>::fromValue(callFrameIdValue, errors);
+    protocol::Value* expressionValue = object ? object->get("expression") : nullptr;
+    errors->setName("expression");
+    String in_expression = ValueConversions<String>::fromValue(expressionValue, errors);
+    protocol::Value* objectGroupValue = object ? object->get("objectGroup") : nullptr;
+    Maybe<String> in_objectGroup;
+    if (objectGroupValue) {
+        errors->setName("objectGroup");
+        in_objectGroup = ValueConversions<String>::fromValue(objectGroupValue, errors);
+    }
+    protocol::Value* includeCommandLineAPIValue = object ? object->get("includeCommandLineAPI") : nullptr;
+    Maybe<bool> in_includeCommandLineAPI;
+    if (includeCommandLineAPIValue) {
+        errors->setName("includeCommandLineAPI");
+        in_includeCommandLineAPI = ValueConversions<bool>::fromValue(includeCommandLineAPIValue, errors);
+    }
+    protocol::Value* silentValue = object ? object->get("silent") : nullptr;
+    Maybe<bool> in_silent;
+    if (silentValue) {
+        errors->setName("silent");
+        in_silent = ValueConversions<bool>::fromValue(silentValue, errors);
+    }
+    protocol::Value* returnByValueValue = object ? object->get("returnByValue") : nullptr;
+    Maybe<bool> in_returnByValue;
+    if (returnByValueValue) {
+        errors->setName("returnByValue");
+        in_returnByValue = ValueConversions<bool>::fromValue(returnByValueValue, errors);
+    }
+    protocol::Value* generatePreviewValue = object ? object->get("generatePreview") : nullptr;
+    Maybe<bool> in_generatePreview;
+    if (generatePreviewValue) {
+        errors->setName("generatePreview");
+        in_generatePreview = ValueConversions<bool>::fromValue(generatePreviewValue, errors);
+    }
+    errors->pop();
+    if (errors->hasErrors()) {
+        reportProtocolError(callId, DispatchResponse::kInvalidParams, kInvalidParamsString, errors);
+        return DispatchResponse::kError;
+    }
+    // Declare output parameters.
+    std::unique_ptr<protocol::Runtime::RemoteObject> out_result;
+    Maybe<protocol::Runtime::ExceptionDetails> out_exceptionDetails;
+
+    std::unique_ptr<DispatcherBase::WeakPtr> weak = weakPtr();
+    DispatchResponse response = m_backend->evaluateOnCallFrame(in_callFrameId, in_expression, std::move(in_objectGroup), std::move(in_includeCommandLineAPI), std::move(in_silent), std::move(in_returnByValue), std::move(in_generatePreview), &out_result, &out_exceptionDetails);
+    if (response.status() == DispatchResponse::kFallThrough)
+        return response.status();
+    std::unique_ptr<protocol::DictionaryValue> result = DictionaryValue::create();
+    if (response.status() == DispatchResponse::kSuccess) {
+        result->setValue("result", ValueConversions<protocol::Runtime::RemoteObject>::toValue(out_result.get()));
+        if (out_exceptionDetails.isJust())
+            result->setValue("exceptionDetails", ValueConversions<protocol::Runtime::ExceptionDetails>::toValue(out_exceptionDetails.fromJust()));
+    }
+    if (weak->get())
+        weak->get()->sendResponse(callId, response, std::move(result));
+    return response.status();
+}
+
+DispatchResponse::Status DispatcherImpl::setVariableValue(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport* errors)
+{
+    // Prepare input parameters.
+    protocol::DictionaryValue* object = DictionaryValue::cast(requestMessageObject->get("params"));
+    errors->push();
+    protocol::Value* scopeNumberValue = object ? object->get("scopeNumber") : nullptr;
+    errors->setName("scopeNumber");
+    int in_scopeNumber = ValueConversions<int>::fromValue(scopeNumberValue, errors);
+    protocol::Value* variableNameValue = object ? object->get("variableName") : nullptr;
+    errors->setName("variableName");
+    String in_variableName = ValueConversions<String>::fromValue(variableNameValue, errors);
+    protocol::Value* newValueValue = object ? object->get("newValue") : nullptr;
+    errors->setName("newValue");
+    std::unique_ptr<protocol::Runtime::CallArgument> in_newValue = ValueConversions<protocol::Runtime::CallArgument>::fromValue(newValueValue, errors);
+    protocol::Value* callFrameIdValue = object ? object->get("callFrameId") : nullptr;
+    errors->setName("callFrameId");
+    String in_callFrameId = ValueConversions<String>::fromValue(callFrameIdValue, errors);
+    errors->pop();
+    if (errors->hasErrors()) {
+        reportProtocolError(callId, DispatchResponse::kInvalidParams, kInvalidParamsString, errors);
+        return DispatchResponse::kError;
+    }
+
+    std::unique_ptr<DispatcherBase::WeakPtr> weak = weakPtr();
+    DispatchResponse response = m_backend->setVariableValue(in_scopeNumber, in_variableName, std::move(in_newValue), in_callFrameId);
+    if (response.status() == DispatchResponse::kFallThrough)
+        return response.status();
+    if (weak->get())
+        weak->get()->sendResponse(callId, response);
+    return response.status();
+}
+
+DispatchResponse::Status DispatcherImpl::setAsyncCallStackDepth(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport* errors)
+{
+    // Prepare input parameters.
+    protocol::DictionaryValue* object = DictionaryValue::cast(requestMessageObject->get("params"));
+    errors->push();
+    protocol::Value* maxDepthValue = object ? object->get("maxDepth") : nullptr;
+    errors->setName("maxDepth");
+    int in_maxDepth = ValueConversions<int>::fromValue(maxDepthValue, errors);
+    errors->pop();
+    if (errors->hasErrors()) {
+        reportProtocolError(callId, DispatchResponse::kInvalidParams, kInvalidParamsString, errors);
+        return DispatchResponse::kError;
+    }
+
+    std::unique_ptr<DispatcherBase::WeakPtr> weak = weakPtr();
+    DispatchResponse response = m_backend->setAsyncCallStackDepth(in_maxDepth);
+    if (response.status() == DispatchResponse::kFallThrough)
+        return response.status();
+    if (weak->get())
+        weak->get()->sendResponse(callId, response);
+    return response.status();
+}
+
+DispatchResponse::Status DispatcherImpl::setBlackboxPatterns(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport* errors)
+{
+    // Prepare input parameters.
+    protocol::DictionaryValue* object = DictionaryValue::cast(requestMessageObject->get("params"));
+    errors->push();
+    protocol::Value* patternsValue = object ? object->get("patterns") : nullptr;
+    errors->setName("patterns");
+    std::unique_ptr<protocol::Array<String>> in_patterns = ValueConversions<protocol::Array<String>>::fromValue(patternsValue, errors);
+    errors->pop();
+    if (errors->hasErrors()) {
+        reportProtocolError(callId, DispatchResponse::kInvalidParams, kInvalidParamsString, errors);
+        return DispatchResponse::kError;
+    }
+
+    std::unique_ptr<DispatcherBase::WeakPtr> weak = weakPtr();
+    DispatchResponse response = m_backend->setBlackboxPatterns(std::move(in_patterns));
+    if (response.status() == DispatchResponse::kFallThrough)
+        return response.status();
+    if (weak->get())
+        weak->get()->sendResponse(callId, response);
+    return response.status();
+}
+
+DispatchResponse::Status DispatcherImpl::setBlackboxedRanges(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport* errors)
+{
+    // Prepare input parameters.
+    protocol::DictionaryValue* object = DictionaryValue::cast(requestMessageObject->get("params"));
+    errors->push();
+    protocol::Value* scriptIdValue = object ? object->get("scriptId") : nullptr;
+    errors->setName("scriptId");
+    String in_scriptId = ValueConversions<String>::fromValue(scriptIdValue, errors);
+    protocol::Value* positionsValue = object ? object->get("positions") : nullptr;
+    errors->setName("positions");
+    std::unique_ptr<protocol::Array<protocol::Debugger::ScriptPosition>> in_positions = ValueConversions<protocol::Array<protocol::Debugger::ScriptPosition>>::fromValue(positionsValue, errors);
+    errors->pop();
+    if (errors->hasErrors()) {
+        reportProtocolError(callId, DispatchResponse::kInvalidParams, kInvalidParamsString, errors);
+        return DispatchResponse::kError;
+    }
+
+    std::unique_ptr<DispatcherBase::WeakPtr> weak = weakPtr();
+    DispatchResponse response = m_backend->setBlackboxedRanges(in_scriptId, std::move(in_positions));
+    if (response.status() == DispatchResponse::kFallThrough)
+        return response.status();
+    if (weak->get())
+        weak->get()->sendResponse(callId, response);
+    return response.status();
+}
+
+// static
+void Dispatcher::wire(UberDispatcher* uber, Backend* backend)
+{
+    std::unique_ptr<DispatcherImpl> dispatcher(new DispatcherImpl(uber->channel(), backend, uber->fallThroughForNotFound()));
+    uber->setupRedirects(dispatcher->redirects());
+    uber->registerBackend("Debugger", std::move(dispatcher));
+}
+
+} // Debugger
+} // namespace JsDebug
+} // namespace protocol

--- a/lib/Debug.Protocol/Generated/protocol/Debugger.h
+++ b/lib/Debug.Protocol/Generated/protocol/Debugger.h
@@ -1,0 +1,1190 @@
+// This file is generated
+
+// Copyright (c) 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef JsDebug_protocol_Debugger_h
+#define JsDebug_protocol_Debugger_h
+
+#include "protocol/Protocol.h"
+// For each imported domain we generate a ValueConversions struct instead of a full domain definition
+// and include Domain::API version from there.
+#include "protocol/Runtime.h"
+#include "include/Debugger.h"
+
+namespace JsDebug {
+namespace protocol {
+namespace Debugger {
+
+// ------------- Forward and enum declarations.
+using BreakpointId = String;
+using CallFrameId = String;
+class Location;
+class ScriptPosition;
+class CallFrame;
+class Scope;
+class SearchMatch;
+class ScriptParsedNotification;
+class ScriptFailedToParseNotification;
+class BreakpointResolvedNotification;
+class PausedNotification;
+using ResumedNotification = Object;
+
+namespace SetPauseOnExceptions {
+namespace StateEnum {
+ extern const char* None;
+ extern const char* Uncaught;
+ extern const char* All;
+} // StateEnum
+} // SetPauseOnExceptions
+
+namespace Paused {
+namespace ReasonEnum {
+ extern const char* XHR;
+ extern const char* DOM;
+ extern const char* EventListener;
+ extern const char* Exception;
+ extern const char* Assert;
+ extern const char* DebugCommand;
+ extern const char* PromiseRejection;
+ extern const char* Other;
+} // ReasonEnum
+} // Paused
+
+// ------------- Type and builder declarations.
+
+class  Location : public Serializable{
+    PROTOCOL_DISALLOW_COPY(Location);
+public:
+    static std::unique_ptr<Location> fromValue(protocol::Value* value, ErrorSupport* errors);
+
+    ~Location() override { }
+
+    String getScriptId() { return m_scriptId; }
+    void setScriptId(const String& value) { m_scriptId = value; }
+
+    int getLineNumber() { return m_lineNumber; }
+    void setLineNumber(int value) { m_lineNumber = value; }
+
+    bool hasColumnNumber() { return m_columnNumber.isJust(); }
+    int getColumnNumber(int defaultValue) { return m_columnNumber.isJust() ? m_columnNumber.fromJust() : defaultValue; }
+    void setColumnNumber(int value) { m_columnNumber = value; }
+
+    std::unique_ptr<protocol::DictionaryValue> toValue() const;
+    String serialize() override { return toValue()->serialize(); }
+    std::unique_ptr<Location> clone() const;
+
+    template<int STATE>
+    class LocationBuilder {
+    public:
+        enum {
+            NoFieldsSet = 0,
+            ScriptIdSet = 1 << 1,
+            LineNumberSet = 1 << 2,
+            AllFieldsSet = (ScriptIdSet | LineNumberSet | 0)};
+
+
+        LocationBuilder<STATE | ScriptIdSet>& setScriptId(const String& value)
+        {
+            static_assert(!(STATE & ScriptIdSet), "property scriptId should not be set yet");
+            m_result->setScriptId(value);
+            return castState<ScriptIdSet>();
+        }
+
+        LocationBuilder<STATE | LineNumberSet>& setLineNumber(int value)
+        {
+            static_assert(!(STATE & LineNumberSet), "property lineNumber should not be set yet");
+            m_result->setLineNumber(value);
+            return castState<LineNumberSet>();
+        }
+
+        LocationBuilder<STATE>& setColumnNumber(int value)
+        {
+            m_result->setColumnNumber(value);
+            return *this;
+        }
+
+        std::unique_ptr<Location> build()
+        {
+            static_assert(STATE == AllFieldsSet, "state should be AllFieldsSet");
+            return std::move(m_result);
+        }
+
+    private:
+        friend class Location;
+        LocationBuilder() : m_result(new Location()) { }
+
+        template<int STEP> LocationBuilder<STATE | STEP>& castState()
+        {
+            return *reinterpret_cast<LocationBuilder<STATE | STEP>*>(this);
+        }
+
+        std::unique_ptr<protocol::Debugger::Location> m_result;
+    };
+
+    static LocationBuilder<0> create()
+    {
+        return LocationBuilder<0>();
+    }
+
+private:
+    Location()
+    {
+          m_lineNumber = 0;
+    }
+
+    String m_scriptId;
+    int m_lineNumber;
+    Maybe<int> m_columnNumber;
+};
+
+
+class  ScriptPosition : public Serializable{
+    PROTOCOL_DISALLOW_COPY(ScriptPosition);
+public:
+    static std::unique_ptr<ScriptPosition> fromValue(protocol::Value* value, ErrorSupport* errors);
+
+    ~ScriptPosition() override { }
+
+    int getLineNumber() { return m_lineNumber; }
+    void setLineNumber(int value) { m_lineNumber = value; }
+
+    int getColumnNumber() { return m_columnNumber; }
+    void setColumnNumber(int value) { m_columnNumber = value; }
+
+    std::unique_ptr<protocol::DictionaryValue> toValue() const;
+    String serialize() override { return toValue()->serialize(); }
+    std::unique_ptr<ScriptPosition> clone() const;
+
+    template<int STATE>
+    class ScriptPositionBuilder {
+    public:
+        enum {
+            NoFieldsSet = 0,
+            LineNumberSet = 1 << 1,
+            ColumnNumberSet = 1 << 2,
+            AllFieldsSet = (LineNumberSet | ColumnNumberSet | 0)};
+
+
+        ScriptPositionBuilder<STATE | LineNumberSet>& setLineNumber(int value)
+        {
+            static_assert(!(STATE & LineNumberSet), "property lineNumber should not be set yet");
+            m_result->setLineNumber(value);
+            return castState<LineNumberSet>();
+        }
+
+        ScriptPositionBuilder<STATE | ColumnNumberSet>& setColumnNumber(int value)
+        {
+            static_assert(!(STATE & ColumnNumberSet), "property columnNumber should not be set yet");
+            m_result->setColumnNumber(value);
+            return castState<ColumnNumberSet>();
+        }
+
+        std::unique_ptr<ScriptPosition> build()
+        {
+            static_assert(STATE == AllFieldsSet, "state should be AllFieldsSet");
+            return std::move(m_result);
+        }
+
+    private:
+        friend class ScriptPosition;
+        ScriptPositionBuilder() : m_result(new ScriptPosition()) { }
+
+        template<int STEP> ScriptPositionBuilder<STATE | STEP>& castState()
+        {
+            return *reinterpret_cast<ScriptPositionBuilder<STATE | STEP>*>(this);
+        }
+
+        std::unique_ptr<protocol::Debugger::ScriptPosition> m_result;
+    };
+
+    static ScriptPositionBuilder<0> create()
+    {
+        return ScriptPositionBuilder<0>();
+    }
+
+private:
+    ScriptPosition()
+    {
+          m_lineNumber = 0;
+          m_columnNumber = 0;
+    }
+
+    int m_lineNumber;
+    int m_columnNumber;
+};
+
+
+class  CallFrame : public Serializable{
+    PROTOCOL_DISALLOW_COPY(CallFrame);
+public:
+    static std::unique_ptr<CallFrame> fromValue(protocol::Value* value, ErrorSupport* errors);
+
+    ~CallFrame() override { }
+
+    String getCallFrameId() { return m_callFrameId; }
+    void setCallFrameId(const String& value) { m_callFrameId = value; }
+
+    String getFunctionName() { return m_functionName; }
+    void setFunctionName(const String& value) { m_functionName = value; }
+
+    bool hasFunctionLocation() { return m_functionLocation.isJust(); }
+    protocol::Debugger::Location* getFunctionLocation(protocol::Debugger::Location* defaultValue) { return m_functionLocation.isJust() ? m_functionLocation.fromJust() : defaultValue; }
+    void setFunctionLocation(std::unique_ptr<protocol::Debugger::Location> value) { m_functionLocation = std::move(value); }
+
+    protocol::Debugger::Location* getLocation() { return m_location.get(); }
+    void setLocation(std::unique_ptr<protocol::Debugger::Location> value) { m_location = std::move(value); }
+
+    protocol::Array<protocol::Debugger::Scope>* getScopeChain() { return m_scopeChain.get(); }
+    void setScopeChain(std::unique_ptr<protocol::Array<protocol::Debugger::Scope>> value) { m_scopeChain = std::move(value); }
+
+    protocol::Runtime::RemoteObject* getThis() { return m_this.get(); }
+    void setThis(std::unique_ptr<protocol::Runtime::RemoteObject> value) { m_this = std::move(value); }
+
+    bool hasReturnValue() { return m_returnValue.isJust(); }
+    protocol::Runtime::RemoteObject* getReturnValue(protocol::Runtime::RemoteObject* defaultValue) { return m_returnValue.isJust() ? m_returnValue.fromJust() : defaultValue; }
+    void setReturnValue(std::unique_ptr<protocol::Runtime::RemoteObject> value) { m_returnValue = std::move(value); }
+
+    std::unique_ptr<protocol::DictionaryValue> toValue() const;
+    String serialize() override { return toValue()->serialize(); }
+    std::unique_ptr<CallFrame> clone() const;
+
+    template<int STATE>
+    class CallFrameBuilder {
+    public:
+        enum {
+            NoFieldsSet = 0,
+            CallFrameIdSet = 1 << 1,
+            FunctionNameSet = 1 << 2,
+            LocationSet = 1 << 3,
+            ScopeChainSet = 1 << 4,
+            ThisSet = 1 << 5,
+            AllFieldsSet = (CallFrameIdSet | FunctionNameSet | LocationSet | ScopeChainSet | ThisSet | 0)};
+
+
+        CallFrameBuilder<STATE | CallFrameIdSet>& setCallFrameId(const String& value)
+        {
+            static_assert(!(STATE & CallFrameIdSet), "property callFrameId should not be set yet");
+            m_result->setCallFrameId(value);
+            return castState<CallFrameIdSet>();
+        }
+
+        CallFrameBuilder<STATE | FunctionNameSet>& setFunctionName(const String& value)
+        {
+            static_assert(!(STATE & FunctionNameSet), "property functionName should not be set yet");
+            m_result->setFunctionName(value);
+            return castState<FunctionNameSet>();
+        }
+
+        CallFrameBuilder<STATE>& setFunctionLocation(std::unique_ptr<protocol::Debugger::Location> value)
+        {
+            m_result->setFunctionLocation(std::move(value));
+            return *this;
+        }
+
+        CallFrameBuilder<STATE | LocationSet>& setLocation(std::unique_ptr<protocol::Debugger::Location> value)
+        {
+            static_assert(!(STATE & LocationSet), "property location should not be set yet");
+            m_result->setLocation(std::move(value));
+            return castState<LocationSet>();
+        }
+
+        CallFrameBuilder<STATE | ScopeChainSet>& setScopeChain(std::unique_ptr<protocol::Array<protocol::Debugger::Scope>> value)
+        {
+            static_assert(!(STATE & ScopeChainSet), "property scopeChain should not be set yet");
+            m_result->setScopeChain(std::move(value));
+            return castState<ScopeChainSet>();
+        }
+
+        CallFrameBuilder<STATE | ThisSet>& setThis(std::unique_ptr<protocol::Runtime::RemoteObject> value)
+        {
+            static_assert(!(STATE & ThisSet), "property this should not be set yet");
+            m_result->setThis(std::move(value));
+            return castState<ThisSet>();
+        }
+
+        CallFrameBuilder<STATE>& setReturnValue(std::unique_ptr<protocol::Runtime::RemoteObject> value)
+        {
+            m_result->setReturnValue(std::move(value));
+            return *this;
+        }
+
+        std::unique_ptr<CallFrame> build()
+        {
+            static_assert(STATE == AllFieldsSet, "state should be AllFieldsSet");
+            return std::move(m_result);
+        }
+
+    private:
+        friend class CallFrame;
+        CallFrameBuilder() : m_result(new CallFrame()) { }
+
+        template<int STEP> CallFrameBuilder<STATE | STEP>& castState()
+        {
+            return *reinterpret_cast<CallFrameBuilder<STATE | STEP>*>(this);
+        }
+
+        std::unique_ptr<protocol::Debugger::CallFrame> m_result;
+    };
+
+    static CallFrameBuilder<0> create()
+    {
+        return CallFrameBuilder<0>();
+    }
+
+private:
+    CallFrame()
+    {
+    }
+
+    String m_callFrameId;
+    String m_functionName;
+    Maybe<protocol::Debugger::Location> m_functionLocation;
+    std::unique_ptr<protocol::Debugger::Location> m_location;
+    std::unique_ptr<protocol::Array<protocol::Debugger::Scope>> m_scopeChain;
+    std::unique_ptr<protocol::Runtime::RemoteObject> m_this;
+    Maybe<protocol::Runtime::RemoteObject> m_returnValue;
+};
+
+
+class  Scope : public Serializable{
+    PROTOCOL_DISALLOW_COPY(Scope);
+public:
+    static std::unique_ptr<Scope> fromValue(protocol::Value* value, ErrorSupport* errors);
+
+    ~Scope() override { }
+
+    struct  TypeEnum {
+        static const char* Global;
+        static const char* Local;
+        static const char* With;
+        static const char* Closure;
+        static const char* Catch;
+        static const char* Block;
+        static const char* Script;
+    }; // TypeEnum
+
+    String getType() { return m_type; }
+    void setType(const String& value) { m_type = value; }
+
+    protocol::Runtime::RemoteObject* getObject() { return m_object.get(); }
+    void setObject(std::unique_ptr<protocol::Runtime::RemoteObject> value) { m_object = std::move(value); }
+
+    bool hasName() { return m_name.isJust(); }
+    String getName(const String& defaultValue) { return m_name.isJust() ? m_name.fromJust() : defaultValue; }
+    void setName(const String& value) { m_name = value; }
+
+    bool hasStartLocation() { return m_startLocation.isJust(); }
+    protocol::Debugger::Location* getStartLocation(protocol::Debugger::Location* defaultValue) { return m_startLocation.isJust() ? m_startLocation.fromJust() : defaultValue; }
+    void setStartLocation(std::unique_ptr<protocol::Debugger::Location> value) { m_startLocation = std::move(value); }
+
+    bool hasEndLocation() { return m_endLocation.isJust(); }
+    protocol::Debugger::Location* getEndLocation(protocol::Debugger::Location* defaultValue) { return m_endLocation.isJust() ? m_endLocation.fromJust() : defaultValue; }
+    void setEndLocation(std::unique_ptr<protocol::Debugger::Location> value) { m_endLocation = std::move(value); }
+
+    std::unique_ptr<protocol::DictionaryValue> toValue() const;
+    String serialize() override { return toValue()->serialize(); }
+    std::unique_ptr<Scope> clone() const;
+
+    template<int STATE>
+    class ScopeBuilder {
+    public:
+        enum {
+            NoFieldsSet = 0,
+            TypeSet = 1 << 1,
+            ObjectSet = 1 << 2,
+            AllFieldsSet = (TypeSet | ObjectSet | 0)};
+
+
+        ScopeBuilder<STATE | TypeSet>& setType(const String& value)
+        {
+            static_assert(!(STATE & TypeSet), "property type should not be set yet");
+            m_result->setType(value);
+            return castState<TypeSet>();
+        }
+
+        ScopeBuilder<STATE | ObjectSet>& setObject(std::unique_ptr<protocol::Runtime::RemoteObject> value)
+        {
+            static_assert(!(STATE & ObjectSet), "property object should not be set yet");
+            m_result->setObject(std::move(value));
+            return castState<ObjectSet>();
+        }
+
+        ScopeBuilder<STATE>& setName(const String& value)
+        {
+            m_result->setName(value);
+            return *this;
+        }
+
+        ScopeBuilder<STATE>& setStartLocation(std::unique_ptr<protocol::Debugger::Location> value)
+        {
+            m_result->setStartLocation(std::move(value));
+            return *this;
+        }
+
+        ScopeBuilder<STATE>& setEndLocation(std::unique_ptr<protocol::Debugger::Location> value)
+        {
+            m_result->setEndLocation(std::move(value));
+            return *this;
+        }
+
+        std::unique_ptr<Scope> build()
+        {
+            static_assert(STATE == AllFieldsSet, "state should be AllFieldsSet");
+            return std::move(m_result);
+        }
+
+    private:
+        friend class Scope;
+        ScopeBuilder() : m_result(new Scope()) { }
+
+        template<int STEP> ScopeBuilder<STATE | STEP>& castState()
+        {
+            return *reinterpret_cast<ScopeBuilder<STATE | STEP>*>(this);
+        }
+
+        std::unique_ptr<protocol::Debugger::Scope> m_result;
+    };
+
+    static ScopeBuilder<0> create()
+    {
+        return ScopeBuilder<0>();
+    }
+
+private:
+    Scope()
+    {
+    }
+
+    String m_type;
+    std::unique_ptr<protocol::Runtime::RemoteObject> m_object;
+    Maybe<String> m_name;
+    Maybe<protocol::Debugger::Location> m_startLocation;
+    Maybe<protocol::Debugger::Location> m_endLocation;
+};
+
+
+class  SearchMatch : public Serializable, public API::SearchMatch{
+    PROTOCOL_DISALLOW_COPY(SearchMatch);
+public:
+    static std::unique_ptr<SearchMatch> fromValue(protocol::Value* value, ErrorSupport* errors);
+
+    ~SearchMatch() override { }
+
+    double getLineNumber() { return m_lineNumber; }
+    void setLineNumber(double value) { m_lineNumber = value; }
+
+    String getLineContent() { return m_lineContent; }
+    void setLineContent(const String& value) { m_lineContent = value; }
+
+    std::unique_ptr<protocol::DictionaryValue> toValue() const;
+    String serialize() override { return toValue()->serialize(); }
+    std::unique_ptr<SearchMatch> clone() const;
+    std::unique_ptr<StringBuffer> toJSONString() const override;
+
+    template<int STATE>
+    class SearchMatchBuilder {
+    public:
+        enum {
+            NoFieldsSet = 0,
+            LineNumberSet = 1 << 1,
+            LineContentSet = 1 << 2,
+            AllFieldsSet = (LineNumberSet | LineContentSet | 0)};
+
+
+        SearchMatchBuilder<STATE | LineNumberSet>& setLineNumber(double value)
+        {
+            static_assert(!(STATE & LineNumberSet), "property lineNumber should not be set yet");
+            m_result->setLineNumber(value);
+            return castState<LineNumberSet>();
+        }
+
+        SearchMatchBuilder<STATE | LineContentSet>& setLineContent(const String& value)
+        {
+            static_assert(!(STATE & LineContentSet), "property lineContent should not be set yet");
+            m_result->setLineContent(value);
+            return castState<LineContentSet>();
+        }
+
+        std::unique_ptr<SearchMatch> build()
+        {
+            static_assert(STATE == AllFieldsSet, "state should be AllFieldsSet");
+            return std::move(m_result);
+        }
+
+    private:
+        friend class SearchMatch;
+        SearchMatchBuilder() : m_result(new SearchMatch()) { }
+
+        template<int STEP> SearchMatchBuilder<STATE | STEP>& castState()
+        {
+            return *reinterpret_cast<SearchMatchBuilder<STATE | STEP>*>(this);
+        }
+
+        std::unique_ptr<protocol::Debugger::SearchMatch> m_result;
+    };
+
+    static SearchMatchBuilder<0> create()
+    {
+        return SearchMatchBuilder<0>();
+    }
+
+private:
+    SearchMatch()
+    {
+          m_lineNumber = 0;
+    }
+
+    double m_lineNumber;
+    String m_lineContent;
+};
+
+
+class  ScriptParsedNotification : public Serializable{
+    PROTOCOL_DISALLOW_COPY(ScriptParsedNotification);
+public:
+    static std::unique_ptr<ScriptParsedNotification> fromValue(protocol::Value* value, ErrorSupport* errors);
+
+    ~ScriptParsedNotification() override { }
+
+    String getScriptId() { return m_scriptId; }
+    void setScriptId(const String& value) { m_scriptId = value; }
+
+    String getUrl() { return m_url; }
+    void setUrl(const String& value) { m_url = value; }
+
+    int getStartLine() { return m_startLine; }
+    void setStartLine(int value) { m_startLine = value; }
+
+    int getStartColumn() { return m_startColumn; }
+    void setStartColumn(int value) { m_startColumn = value; }
+
+    int getEndLine() { return m_endLine; }
+    void setEndLine(int value) { m_endLine = value; }
+
+    int getEndColumn() { return m_endColumn; }
+    void setEndColumn(int value) { m_endColumn = value; }
+
+    int getExecutionContextId() { return m_executionContextId; }
+    void setExecutionContextId(int value) { m_executionContextId = value; }
+
+    String getHash() { return m_hash; }
+    void setHash(const String& value) { m_hash = value; }
+
+    bool hasExecutionContextAuxData() { return m_executionContextAuxData.isJust(); }
+    protocol::DictionaryValue* getExecutionContextAuxData(protocol::DictionaryValue* defaultValue) { return m_executionContextAuxData.isJust() ? m_executionContextAuxData.fromJust() : defaultValue; }
+    void setExecutionContextAuxData(std::unique_ptr<protocol::DictionaryValue> value) { m_executionContextAuxData = std::move(value); }
+
+    bool hasIsLiveEdit() { return m_isLiveEdit.isJust(); }
+    bool getIsLiveEdit(bool defaultValue) { return m_isLiveEdit.isJust() ? m_isLiveEdit.fromJust() : defaultValue; }
+    void setIsLiveEdit(bool value) { m_isLiveEdit = value; }
+
+    bool hasSourceMapURL() { return m_sourceMapURL.isJust(); }
+    String getSourceMapURL(const String& defaultValue) { return m_sourceMapURL.isJust() ? m_sourceMapURL.fromJust() : defaultValue; }
+    void setSourceMapURL(const String& value) { m_sourceMapURL = value; }
+
+    bool hasHasSourceURL() { return m_hasSourceURL.isJust(); }
+    bool getHasSourceURL(bool defaultValue) { return m_hasSourceURL.isJust() ? m_hasSourceURL.fromJust() : defaultValue; }
+    void setHasSourceURL(bool value) { m_hasSourceURL = value; }
+
+    std::unique_ptr<protocol::DictionaryValue> toValue() const;
+    String serialize() override { return toValue()->serialize(); }
+    std::unique_ptr<ScriptParsedNotification> clone() const;
+
+    template<int STATE>
+    class ScriptParsedNotificationBuilder {
+    public:
+        enum {
+            NoFieldsSet = 0,
+            ScriptIdSet = 1 << 1,
+            UrlSet = 1 << 2,
+            StartLineSet = 1 << 3,
+            StartColumnSet = 1 << 4,
+            EndLineSet = 1 << 5,
+            EndColumnSet = 1 << 6,
+            ExecutionContextIdSet = 1 << 7,
+            HashSet = 1 << 8,
+            AllFieldsSet = (ScriptIdSet | UrlSet | StartLineSet | StartColumnSet | EndLineSet | EndColumnSet | ExecutionContextIdSet | HashSet | 0)};
+
+
+        ScriptParsedNotificationBuilder<STATE | ScriptIdSet>& setScriptId(const String& value)
+        {
+            static_assert(!(STATE & ScriptIdSet), "property scriptId should not be set yet");
+            m_result->setScriptId(value);
+            return castState<ScriptIdSet>();
+        }
+
+        ScriptParsedNotificationBuilder<STATE | UrlSet>& setUrl(const String& value)
+        {
+            static_assert(!(STATE & UrlSet), "property url should not be set yet");
+            m_result->setUrl(value);
+            return castState<UrlSet>();
+        }
+
+        ScriptParsedNotificationBuilder<STATE | StartLineSet>& setStartLine(int value)
+        {
+            static_assert(!(STATE & StartLineSet), "property startLine should not be set yet");
+            m_result->setStartLine(value);
+            return castState<StartLineSet>();
+        }
+
+        ScriptParsedNotificationBuilder<STATE | StartColumnSet>& setStartColumn(int value)
+        {
+            static_assert(!(STATE & StartColumnSet), "property startColumn should not be set yet");
+            m_result->setStartColumn(value);
+            return castState<StartColumnSet>();
+        }
+
+        ScriptParsedNotificationBuilder<STATE | EndLineSet>& setEndLine(int value)
+        {
+            static_assert(!(STATE & EndLineSet), "property endLine should not be set yet");
+            m_result->setEndLine(value);
+            return castState<EndLineSet>();
+        }
+
+        ScriptParsedNotificationBuilder<STATE | EndColumnSet>& setEndColumn(int value)
+        {
+            static_assert(!(STATE & EndColumnSet), "property endColumn should not be set yet");
+            m_result->setEndColumn(value);
+            return castState<EndColumnSet>();
+        }
+
+        ScriptParsedNotificationBuilder<STATE | ExecutionContextIdSet>& setExecutionContextId(int value)
+        {
+            static_assert(!(STATE & ExecutionContextIdSet), "property executionContextId should not be set yet");
+            m_result->setExecutionContextId(value);
+            return castState<ExecutionContextIdSet>();
+        }
+
+        ScriptParsedNotificationBuilder<STATE | HashSet>& setHash(const String& value)
+        {
+            static_assert(!(STATE & HashSet), "property hash should not be set yet");
+            m_result->setHash(value);
+            return castState<HashSet>();
+        }
+
+        ScriptParsedNotificationBuilder<STATE>& setExecutionContextAuxData(std::unique_ptr<protocol::DictionaryValue> value)
+        {
+            m_result->setExecutionContextAuxData(std::move(value));
+            return *this;
+        }
+
+        ScriptParsedNotificationBuilder<STATE>& setIsLiveEdit(bool value)
+        {
+            m_result->setIsLiveEdit(value);
+            return *this;
+        }
+
+        ScriptParsedNotificationBuilder<STATE>& setSourceMapURL(const String& value)
+        {
+            m_result->setSourceMapURL(value);
+            return *this;
+        }
+
+        ScriptParsedNotificationBuilder<STATE>& setHasSourceURL(bool value)
+        {
+            m_result->setHasSourceURL(value);
+            return *this;
+        }
+
+        std::unique_ptr<ScriptParsedNotification> build()
+        {
+            static_assert(STATE == AllFieldsSet, "state should be AllFieldsSet");
+            return std::move(m_result);
+        }
+
+    private:
+        friend class ScriptParsedNotification;
+        ScriptParsedNotificationBuilder() : m_result(new ScriptParsedNotification()) { }
+
+        template<int STEP> ScriptParsedNotificationBuilder<STATE | STEP>& castState()
+        {
+            return *reinterpret_cast<ScriptParsedNotificationBuilder<STATE | STEP>*>(this);
+        }
+
+        std::unique_ptr<protocol::Debugger::ScriptParsedNotification> m_result;
+    };
+
+    static ScriptParsedNotificationBuilder<0> create()
+    {
+        return ScriptParsedNotificationBuilder<0>();
+    }
+
+private:
+    ScriptParsedNotification()
+    {
+          m_startLine = 0;
+          m_startColumn = 0;
+          m_endLine = 0;
+          m_endColumn = 0;
+          m_executionContextId = 0;
+    }
+
+    String m_scriptId;
+    String m_url;
+    int m_startLine;
+    int m_startColumn;
+    int m_endLine;
+    int m_endColumn;
+    int m_executionContextId;
+    String m_hash;
+    Maybe<protocol::DictionaryValue> m_executionContextAuxData;
+    Maybe<bool> m_isLiveEdit;
+    Maybe<String> m_sourceMapURL;
+    Maybe<bool> m_hasSourceURL;
+};
+
+
+class  ScriptFailedToParseNotification : public Serializable{
+    PROTOCOL_DISALLOW_COPY(ScriptFailedToParseNotification);
+public:
+    static std::unique_ptr<ScriptFailedToParseNotification> fromValue(protocol::Value* value, ErrorSupport* errors);
+
+    ~ScriptFailedToParseNotification() override { }
+
+    String getScriptId() { return m_scriptId; }
+    void setScriptId(const String& value) { m_scriptId = value; }
+
+    String getUrl() { return m_url; }
+    void setUrl(const String& value) { m_url = value; }
+
+    int getStartLine() { return m_startLine; }
+    void setStartLine(int value) { m_startLine = value; }
+
+    int getStartColumn() { return m_startColumn; }
+    void setStartColumn(int value) { m_startColumn = value; }
+
+    int getEndLine() { return m_endLine; }
+    void setEndLine(int value) { m_endLine = value; }
+
+    int getEndColumn() { return m_endColumn; }
+    void setEndColumn(int value) { m_endColumn = value; }
+
+    int getExecutionContextId() { return m_executionContextId; }
+    void setExecutionContextId(int value) { m_executionContextId = value; }
+
+    String getHash() { return m_hash; }
+    void setHash(const String& value) { m_hash = value; }
+
+    bool hasExecutionContextAuxData() { return m_executionContextAuxData.isJust(); }
+    protocol::DictionaryValue* getExecutionContextAuxData(protocol::DictionaryValue* defaultValue) { return m_executionContextAuxData.isJust() ? m_executionContextAuxData.fromJust() : defaultValue; }
+    void setExecutionContextAuxData(std::unique_ptr<protocol::DictionaryValue> value) { m_executionContextAuxData = std::move(value); }
+
+    bool hasSourceMapURL() { return m_sourceMapURL.isJust(); }
+    String getSourceMapURL(const String& defaultValue) { return m_sourceMapURL.isJust() ? m_sourceMapURL.fromJust() : defaultValue; }
+    void setSourceMapURL(const String& value) { m_sourceMapURL = value; }
+
+    bool hasHasSourceURL() { return m_hasSourceURL.isJust(); }
+    bool getHasSourceURL(bool defaultValue) { return m_hasSourceURL.isJust() ? m_hasSourceURL.fromJust() : defaultValue; }
+    void setHasSourceURL(bool value) { m_hasSourceURL = value; }
+
+    std::unique_ptr<protocol::DictionaryValue> toValue() const;
+    String serialize() override { return toValue()->serialize(); }
+    std::unique_ptr<ScriptFailedToParseNotification> clone() const;
+
+    template<int STATE>
+    class ScriptFailedToParseNotificationBuilder {
+    public:
+        enum {
+            NoFieldsSet = 0,
+            ScriptIdSet = 1 << 1,
+            UrlSet = 1 << 2,
+            StartLineSet = 1 << 3,
+            StartColumnSet = 1 << 4,
+            EndLineSet = 1 << 5,
+            EndColumnSet = 1 << 6,
+            ExecutionContextIdSet = 1 << 7,
+            HashSet = 1 << 8,
+            AllFieldsSet = (ScriptIdSet | UrlSet | StartLineSet | StartColumnSet | EndLineSet | EndColumnSet | ExecutionContextIdSet | HashSet | 0)};
+
+
+        ScriptFailedToParseNotificationBuilder<STATE | ScriptIdSet>& setScriptId(const String& value)
+        {
+            static_assert(!(STATE & ScriptIdSet), "property scriptId should not be set yet");
+            m_result->setScriptId(value);
+            return castState<ScriptIdSet>();
+        }
+
+        ScriptFailedToParseNotificationBuilder<STATE | UrlSet>& setUrl(const String& value)
+        {
+            static_assert(!(STATE & UrlSet), "property url should not be set yet");
+            m_result->setUrl(value);
+            return castState<UrlSet>();
+        }
+
+        ScriptFailedToParseNotificationBuilder<STATE | StartLineSet>& setStartLine(int value)
+        {
+            static_assert(!(STATE & StartLineSet), "property startLine should not be set yet");
+            m_result->setStartLine(value);
+            return castState<StartLineSet>();
+        }
+
+        ScriptFailedToParseNotificationBuilder<STATE | StartColumnSet>& setStartColumn(int value)
+        {
+            static_assert(!(STATE & StartColumnSet), "property startColumn should not be set yet");
+            m_result->setStartColumn(value);
+            return castState<StartColumnSet>();
+        }
+
+        ScriptFailedToParseNotificationBuilder<STATE | EndLineSet>& setEndLine(int value)
+        {
+            static_assert(!(STATE & EndLineSet), "property endLine should not be set yet");
+            m_result->setEndLine(value);
+            return castState<EndLineSet>();
+        }
+
+        ScriptFailedToParseNotificationBuilder<STATE | EndColumnSet>& setEndColumn(int value)
+        {
+            static_assert(!(STATE & EndColumnSet), "property endColumn should not be set yet");
+            m_result->setEndColumn(value);
+            return castState<EndColumnSet>();
+        }
+
+        ScriptFailedToParseNotificationBuilder<STATE | ExecutionContextIdSet>& setExecutionContextId(int value)
+        {
+            static_assert(!(STATE & ExecutionContextIdSet), "property executionContextId should not be set yet");
+            m_result->setExecutionContextId(value);
+            return castState<ExecutionContextIdSet>();
+        }
+
+        ScriptFailedToParseNotificationBuilder<STATE | HashSet>& setHash(const String& value)
+        {
+            static_assert(!(STATE & HashSet), "property hash should not be set yet");
+            m_result->setHash(value);
+            return castState<HashSet>();
+        }
+
+        ScriptFailedToParseNotificationBuilder<STATE>& setExecutionContextAuxData(std::unique_ptr<protocol::DictionaryValue> value)
+        {
+            m_result->setExecutionContextAuxData(std::move(value));
+            return *this;
+        }
+
+        ScriptFailedToParseNotificationBuilder<STATE>& setSourceMapURL(const String& value)
+        {
+            m_result->setSourceMapURL(value);
+            return *this;
+        }
+
+        ScriptFailedToParseNotificationBuilder<STATE>& setHasSourceURL(bool value)
+        {
+            m_result->setHasSourceURL(value);
+            return *this;
+        }
+
+        std::unique_ptr<ScriptFailedToParseNotification> build()
+        {
+            static_assert(STATE == AllFieldsSet, "state should be AllFieldsSet");
+            return std::move(m_result);
+        }
+
+    private:
+        friend class ScriptFailedToParseNotification;
+        ScriptFailedToParseNotificationBuilder() : m_result(new ScriptFailedToParseNotification()) { }
+
+        template<int STEP> ScriptFailedToParseNotificationBuilder<STATE | STEP>& castState()
+        {
+            return *reinterpret_cast<ScriptFailedToParseNotificationBuilder<STATE | STEP>*>(this);
+        }
+
+        std::unique_ptr<protocol::Debugger::ScriptFailedToParseNotification> m_result;
+    };
+
+    static ScriptFailedToParseNotificationBuilder<0> create()
+    {
+        return ScriptFailedToParseNotificationBuilder<0>();
+    }
+
+private:
+    ScriptFailedToParseNotification()
+    {
+          m_startLine = 0;
+          m_startColumn = 0;
+          m_endLine = 0;
+          m_endColumn = 0;
+          m_executionContextId = 0;
+    }
+
+    String m_scriptId;
+    String m_url;
+    int m_startLine;
+    int m_startColumn;
+    int m_endLine;
+    int m_endColumn;
+    int m_executionContextId;
+    String m_hash;
+    Maybe<protocol::DictionaryValue> m_executionContextAuxData;
+    Maybe<String> m_sourceMapURL;
+    Maybe<bool> m_hasSourceURL;
+};
+
+
+class  BreakpointResolvedNotification : public Serializable{
+    PROTOCOL_DISALLOW_COPY(BreakpointResolvedNotification);
+public:
+    static std::unique_ptr<BreakpointResolvedNotification> fromValue(protocol::Value* value, ErrorSupport* errors);
+
+    ~BreakpointResolvedNotification() override { }
+
+    String getBreakpointId() { return m_breakpointId; }
+    void setBreakpointId(const String& value) { m_breakpointId = value; }
+
+    protocol::Debugger::Location* getLocation() { return m_location.get(); }
+    void setLocation(std::unique_ptr<protocol::Debugger::Location> value) { m_location = std::move(value); }
+
+    std::unique_ptr<protocol::DictionaryValue> toValue() const;
+    String serialize() override { return toValue()->serialize(); }
+    std::unique_ptr<BreakpointResolvedNotification> clone() const;
+
+    template<int STATE>
+    class BreakpointResolvedNotificationBuilder {
+    public:
+        enum {
+            NoFieldsSet = 0,
+            BreakpointIdSet = 1 << 1,
+            LocationSet = 1 << 2,
+            AllFieldsSet = (BreakpointIdSet | LocationSet | 0)};
+
+
+        BreakpointResolvedNotificationBuilder<STATE | BreakpointIdSet>& setBreakpointId(const String& value)
+        {
+            static_assert(!(STATE & BreakpointIdSet), "property breakpointId should not be set yet");
+            m_result->setBreakpointId(value);
+            return castState<BreakpointIdSet>();
+        }
+
+        BreakpointResolvedNotificationBuilder<STATE | LocationSet>& setLocation(std::unique_ptr<protocol::Debugger::Location> value)
+        {
+            static_assert(!(STATE & LocationSet), "property location should not be set yet");
+            m_result->setLocation(std::move(value));
+            return castState<LocationSet>();
+        }
+
+        std::unique_ptr<BreakpointResolvedNotification> build()
+        {
+            static_assert(STATE == AllFieldsSet, "state should be AllFieldsSet");
+            return std::move(m_result);
+        }
+
+    private:
+        friend class BreakpointResolvedNotification;
+        BreakpointResolvedNotificationBuilder() : m_result(new BreakpointResolvedNotification()) { }
+
+        template<int STEP> BreakpointResolvedNotificationBuilder<STATE | STEP>& castState()
+        {
+            return *reinterpret_cast<BreakpointResolvedNotificationBuilder<STATE | STEP>*>(this);
+        }
+
+        std::unique_ptr<protocol::Debugger::BreakpointResolvedNotification> m_result;
+    };
+
+    static BreakpointResolvedNotificationBuilder<0> create()
+    {
+        return BreakpointResolvedNotificationBuilder<0>();
+    }
+
+private:
+    BreakpointResolvedNotification()
+    {
+    }
+
+    String m_breakpointId;
+    std::unique_ptr<protocol::Debugger::Location> m_location;
+};
+
+
+class  PausedNotification : public Serializable{
+    PROTOCOL_DISALLOW_COPY(PausedNotification);
+public:
+    static std::unique_ptr<PausedNotification> fromValue(protocol::Value* value, ErrorSupport* errors);
+
+    ~PausedNotification() override { }
+
+    protocol::Array<protocol::Debugger::CallFrame>* getCallFrames() { return m_callFrames.get(); }
+    void setCallFrames(std::unique_ptr<protocol::Array<protocol::Debugger::CallFrame>> value) { m_callFrames = std::move(value); }
+
+    struct  ReasonEnum {
+        static const char* XHR;
+        static const char* DOM;
+        static const char* EventListener;
+        static const char* Exception;
+        static const char* Assert;
+        static const char* DebugCommand;
+        static const char* PromiseRejection;
+        static const char* Other;
+    }; // ReasonEnum
+
+    String getReason() { return m_reason; }
+    void setReason(const String& value) { m_reason = value; }
+
+    bool hasData() { return m_data.isJust(); }
+    protocol::DictionaryValue* getData(protocol::DictionaryValue* defaultValue) { return m_data.isJust() ? m_data.fromJust() : defaultValue; }
+    void setData(std::unique_ptr<protocol::DictionaryValue> value) { m_data = std::move(value); }
+
+    bool hasHitBreakpoints() { return m_hitBreakpoints.isJust(); }
+    protocol::Array<String>* getHitBreakpoints(protocol::Array<String>* defaultValue) { return m_hitBreakpoints.isJust() ? m_hitBreakpoints.fromJust() : defaultValue; }
+    void setHitBreakpoints(std::unique_ptr<protocol::Array<String>> value) { m_hitBreakpoints = std::move(value); }
+
+    bool hasAsyncStackTrace() { return m_asyncStackTrace.isJust(); }
+    protocol::Runtime::StackTrace* getAsyncStackTrace(protocol::Runtime::StackTrace* defaultValue) { return m_asyncStackTrace.isJust() ? m_asyncStackTrace.fromJust() : defaultValue; }
+    void setAsyncStackTrace(std::unique_ptr<protocol::Runtime::StackTrace> value) { m_asyncStackTrace = std::move(value); }
+
+    std::unique_ptr<protocol::DictionaryValue> toValue() const;
+    String serialize() override { return toValue()->serialize(); }
+    std::unique_ptr<PausedNotification> clone() const;
+
+    template<int STATE>
+    class PausedNotificationBuilder {
+    public:
+        enum {
+            NoFieldsSet = 0,
+            CallFramesSet = 1 << 1,
+            ReasonSet = 1 << 2,
+            AllFieldsSet = (CallFramesSet | ReasonSet | 0)};
+
+
+        PausedNotificationBuilder<STATE | CallFramesSet>& setCallFrames(std::unique_ptr<protocol::Array<protocol::Debugger::CallFrame>> value)
+        {
+            static_assert(!(STATE & CallFramesSet), "property callFrames should not be set yet");
+            m_result->setCallFrames(std::move(value));
+            return castState<CallFramesSet>();
+        }
+
+        PausedNotificationBuilder<STATE | ReasonSet>& setReason(const String& value)
+        {
+            static_assert(!(STATE & ReasonSet), "property reason should not be set yet");
+            m_result->setReason(value);
+            return castState<ReasonSet>();
+        }
+
+        PausedNotificationBuilder<STATE>& setData(std::unique_ptr<protocol::DictionaryValue> value)
+        {
+            m_result->setData(std::move(value));
+            return *this;
+        }
+
+        PausedNotificationBuilder<STATE>& setHitBreakpoints(std::unique_ptr<protocol::Array<String>> value)
+        {
+            m_result->setHitBreakpoints(std::move(value));
+            return *this;
+        }
+
+        PausedNotificationBuilder<STATE>& setAsyncStackTrace(std::unique_ptr<protocol::Runtime::StackTrace> value)
+        {
+            m_result->setAsyncStackTrace(std::move(value));
+            return *this;
+        }
+
+        std::unique_ptr<PausedNotification> build()
+        {
+            static_assert(STATE == AllFieldsSet, "state should be AllFieldsSet");
+            return std::move(m_result);
+        }
+
+    private:
+        friend class PausedNotification;
+        PausedNotificationBuilder() : m_result(new PausedNotification()) { }
+
+        template<int STEP> PausedNotificationBuilder<STATE | STEP>& castState()
+        {
+            return *reinterpret_cast<PausedNotificationBuilder<STATE | STEP>*>(this);
+        }
+
+        std::unique_ptr<protocol::Debugger::PausedNotification> m_result;
+    };
+
+    static PausedNotificationBuilder<0> create()
+    {
+        return PausedNotificationBuilder<0>();
+    }
+
+private:
+    PausedNotification()
+    {
+    }
+
+    std::unique_ptr<protocol::Array<protocol::Debugger::CallFrame>> m_callFrames;
+    String m_reason;
+    Maybe<protocol::DictionaryValue> m_data;
+    Maybe<protocol::Array<String>> m_hitBreakpoints;
+    Maybe<protocol::Runtime::StackTrace> m_asyncStackTrace;
+};
+
+
+// ------------- Backend interface.
+
+class  Backend {
+public:
+    virtual ~Backend() { }
+
+    virtual DispatchResponse enable() = 0;
+    virtual DispatchResponse disable() = 0;
+    virtual DispatchResponse setBreakpointsActive(bool in_active) = 0;
+    virtual DispatchResponse setSkipAllPauses(bool in_skip) = 0;
+    virtual DispatchResponse setBreakpointByUrl(int in_lineNumber, Maybe<String> in_url, Maybe<String> in_urlRegex, Maybe<int> in_columnNumber, Maybe<String> in_condition, String* out_breakpointId, std::unique_ptr<protocol::Array<protocol::Debugger::Location>>* out_locations) = 0;
+    virtual DispatchResponse setBreakpoint(std::unique_ptr<protocol::Debugger::Location> in_location, Maybe<String> in_condition, String* out_breakpointId, std::unique_ptr<protocol::Debugger::Location>* out_actualLocation) = 0;
+    virtual DispatchResponse removeBreakpoint(const String& in_breakpointId) = 0;
+    virtual DispatchResponse continueToLocation(std::unique_ptr<protocol::Debugger::Location> in_location) = 0;
+    virtual DispatchResponse stepOver() = 0;
+    virtual DispatchResponse stepInto() = 0;
+    virtual DispatchResponse stepOut() = 0;
+    virtual DispatchResponse pause() = 0;
+    virtual DispatchResponse resume() = 0;
+    virtual DispatchResponse searchInContent(const String& in_scriptId, const String& in_query, Maybe<bool> in_caseSensitive, Maybe<bool> in_isRegex, std::unique_ptr<protocol::Array<protocol::Debugger::SearchMatch>>* out_result) = 0;
+    virtual DispatchResponse setScriptSource(const String& in_scriptId, const String& in_scriptSource, Maybe<bool> in_dryRun, Maybe<protocol::Array<protocol::Debugger::CallFrame>>* out_callFrames, Maybe<bool>* out_stackChanged, Maybe<protocol::Runtime::StackTrace>* out_asyncStackTrace, Maybe<protocol::Runtime::ExceptionDetails>* out_exceptionDetails) = 0;
+    virtual DispatchResponse restartFrame(const String& in_callFrameId, std::unique_ptr<protocol::Array<protocol::Debugger::CallFrame>>* out_callFrames, Maybe<protocol::Runtime::StackTrace>* out_asyncStackTrace) = 0;
+    virtual DispatchResponse getScriptSource(const String& in_scriptId, String* out_scriptSource) = 0;
+    virtual DispatchResponse setPauseOnExceptions(const String& in_state) = 0;
+    virtual DispatchResponse evaluateOnCallFrame(const String& in_callFrameId, const String& in_expression, Maybe<String> in_objectGroup, Maybe<bool> in_includeCommandLineAPI, Maybe<bool> in_silent, Maybe<bool> in_returnByValue, Maybe<bool> in_generatePreview, std::unique_ptr<protocol::Runtime::RemoteObject>* out_result, Maybe<protocol::Runtime::ExceptionDetails>* out_exceptionDetails) = 0;
+    virtual DispatchResponse setVariableValue(int in_scopeNumber, const String& in_variableName, std::unique_ptr<protocol::Runtime::CallArgument> in_newValue, const String& in_callFrameId) = 0;
+    virtual DispatchResponse setAsyncCallStackDepth(int in_maxDepth) = 0;
+    virtual DispatchResponse setBlackboxPatterns(std::unique_ptr<protocol::Array<String>> in_patterns) = 0;
+    virtual DispatchResponse setBlackboxedRanges(const String& in_scriptId, std::unique_ptr<protocol::Array<protocol::Debugger::ScriptPosition>> in_positions) = 0;
+
+};
+
+// ------------- Frontend interface.
+
+class  Frontend {
+public:
+    explicit Frontend(FrontendChannel* frontendChannel) : m_frontendChannel(frontendChannel) { }
+    void scriptParsed(const String& scriptId, const String& url, int startLine, int startColumn, int endLine, int endColumn, int executionContextId, const String& hash, Maybe<protocol::DictionaryValue> executionContextAuxData = Maybe<protocol::DictionaryValue>(), Maybe<bool> isLiveEdit = Maybe<bool>(), Maybe<String> sourceMapURL = Maybe<String>(), Maybe<bool> hasSourceURL = Maybe<bool>());
+    void scriptFailedToParse(const String& scriptId, const String& url, int startLine, int startColumn, int endLine, int endColumn, int executionContextId, const String& hash, Maybe<protocol::DictionaryValue> executionContextAuxData = Maybe<protocol::DictionaryValue>(), Maybe<String> sourceMapURL = Maybe<String>(), Maybe<bool> hasSourceURL = Maybe<bool>());
+    void breakpointResolved(const String& breakpointId, std::unique_ptr<protocol::Debugger::Location> location);
+    void paused(std::unique_ptr<protocol::Array<protocol::Debugger::CallFrame>> callFrames, const String& reason, Maybe<protocol::DictionaryValue> data = Maybe<protocol::DictionaryValue>(), Maybe<protocol::Array<String>> hitBreakpoints = Maybe<protocol::Array<String>>(), Maybe<protocol::Runtime::StackTrace> asyncStackTrace = Maybe<protocol::Runtime::StackTrace>());
+    void resumed();
+
+    void flush();
+    void sendRawNotification(const String&);
+private:
+    FrontendChannel* m_frontendChannel;
+};
+
+// ------------- Dispatcher.
+
+class  Dispatcher {
+public:
+    static void wire(UberDispatcher*, Backend*);
+
+private:
+    Dispatcher() { }
+};
+
+// ------------- Metainfo.
+
+class  Metainfo {
+public:
+    using BackendClass = Backend;
+    using FrontendClass = Frontend;
+    using DispatcherClass = Dispatcher;
+    static const char domainName[];
+    static const char commandPrefix[];
+    static const char version[];
+};
+
+} // namespace Debugger
+} // namespace JsDebug
+} // namespace protocol
+
+#endif // !defined(JsDebug_protocol_Debugger_h)

--- a/lib/Debug.Protocol/Generated/protocol/Forward.h
+++ b/lib/Debug.Protocol/Generated/protocol/Forward.h
@@ -1,0 +1,92 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef JsDebug_protocol_Forward_h
+#define JsDebug_protocol_Forward_h
+
+#include "StringUtil.h"
+
+#include <vector>
+
+namespace JsDebug {
+namespace protocol {
+
+template<typename T> class Array;
+class DictionaryValue;
+class DispatchResponse;
+class ErrorSupport;
+class FundamentalValue;
+class ListValue;
+template<typename T> class Maybe;
+class Object;
+using Response = DispatchResponse;
+class SerializedValue;
+class StringValue;
+class UberDispatcher;
+class Value;
+
+} // namespace JsDebug
+} // namespace protocol
+
+#endif // !defined(JsDebug_protocol_Forward_h)
+
+
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef JsDebug_protocol_Allocator_h
+#define JsDebug_protocol_Allocator_h
+
+namespace JsDebug {
+namespace protocol {
+
+enum NotNullTagEnum { NotNullLiteral };
+
+#define PROTOCOL_DISALLOW_NEW()                                 \
+    private:                                                    \
+        void* operator new(size_t) = delete;                    \
+        void* operator new(size_t, NotNullTagEnum, void*) = delete; \
+        void* operator new(size_t, void*) = delete;             \
+    public:
+
+#define PROTOCOL_DISALLOW_COPY(ClassName) \
+    private: \
+        ClassName(const ClassName&) = delete; \
+        ClassName& operator=(const ClassName&) = delete
+
+} // namespace JsDebug
+} // namespace protocol
+
+#endif // !defined(JsDebug_protocol_Allocator_h)
+
+
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef JsDebug_protocol_FrontendChannel_h
+#define JsDebug_protocol_FrontendChannel_h
+
+namespace JsDebug {
+namespace protocol {
+
+class  Serializable {
+public:
+    virtual String serialize() = 0;
+    virtual ~Serializable() = default;
+};
+
+class  FrontendChannel {
+public:
+    virtual ~FrontendChannel() { }
+    virtual void sendProtocolResponse(int callId, std::unique_ptr<Serializable> message) = 0;
+    virtual void sendProtocolNotification(std::unique_ptr<Serializable> message) = 0;
+    virtual void flushProtocolNotifications() = 0;
+};
+
+} // namespace JsDebug
+} // namespace protocol
+
+#endif // !defined(JsDebug_protocol_FrontendChannel_h)

--- a/lib/Debug.Protocol/Generated/protocol/Protocol.cpp
+++ b/lib/Debug.Protocol/Generated/protocol/Protocol.cpp
@@ -1,0 +1,1431 @@
+// This file is generated.
+
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "protocol/Protocol.h"
+
+#include <algorithm>
+#include <cmath>
+
+#include <cstring>
+
+
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+//#include "ErrorSupport.h"
+
+namespace JsDebug {
+namespace protocol {
+
+ErrorSupport::ErrorSupport() { }
+ErrorSupport::~ErrorSupport() { }
+
+void ErrorSupport::setName(const char* name)
+{
+    setName(String(name));
+}
+
+void ErrorSupport::setName(const String& name)
+{
+    DCHECK(m_path.size());
+    m_path[m_path.size() - 1] = name;
+}
+
+void ErrorSupport::push()
+{
+    m_path.push_back(String());
+}
+
+void ErrorSupport::pop()
+{
+    m_path.pop_back();
+}
+
+void ErrorSupport::addError(const char* error)
+{
+    addError(String(error));
+}
+
+void ErrorSupport::addError(const String& error)
+{
+    StringBuilder builder;
+    for (size_t i = 0; i < m_path.size(); ++i) {
+        if (i)
+            StringUtil::builderAppend(builder, '.');
+        StringUtil::builderAppend(builder, m_path[i]);
+    }
+    StringUtil::builderAppend(builder, ": ");
+    StringUtil::builderAppend(builder, error);
+    m_errors.push_back(StringUtil::builderToString(builder));
+}
+
+bool ErrorSupport::hasErrors()
+{
+    return !!m_errors.size();
+}
+
+String ErrorSupport::errors()
+{
+    StringBuilder builder;
+    for (size_t i = 0; i < m_errors.size(); ++i) {
+        if (i)
+            StringUtil::builderAppend(builder, "; ");
+        StringUtil::builderAppend(builder, m_errors[i]);
+    }
+    return StringUtil::builderToString(builder);
+}
+
+} // namespace JsDebug
+} // namespace protocol
+
+
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+//#include "Values.h"
+
+namespace JsDebug {
+namespace protocol {
+
+namespace {
+
+const char* const nullValueString = "null";
+const char* const trueValueString = "true";
+const char* const falseValueString = "false";
+
+inline bool escapeChar(uint16_t c, StringBuilder* dst)
+{
+    switch (c) {
+    case '\b': StringUtil::builderAppend(*dst, "\\b"); break;
+    case '\f': StringUtil::builderAppend(*dst, "\\f"); break;
+    case '\n': StringUtil::builderAppend(*dst, "\\n"); break;
+    case '\r': StringUtil::builderAppend(*dst, "\\r"); break;
+    case '\t': StringUtil::builderAppend(*dst, "\\t"); break;
+    case '\\': StringUtil::builderAppend(*dst, "\\\\"); break;
+    case '"': StringUtil::builderAppend(*dst, "\\\""); break;
+    default:
+        return false;
+    }
+    return true;
+}
+
+const char hexDigits[17] = "0123456789ABCDEF";
+
+void appendUnsignedAsHex(uint16_t number, StringBuilder* dst)
+{
+    StringUtil::builderAppend(*dst, "\\u");
+    for (size_t i = 0; i < 4; ++i) {
+        uint16_t c = hexDigits[(number & 0xF000) >> 12];
+        StringUtil::builderAppend(*dst, c);
+        number <<= 4;
+    }
+}
+
+template <typename Char>
+void escapeStringForJSONInternal(const Char* str, unsigned len,
+                                 StringBuilder* dst)
+{
+    for (unsigned i = 0; i < len; ++i) {
+        Char c = str[i];
+        if (escapeChar(c, dst))
+            continue;
+        if (c < 32 || c > 126) {
+            appendUnsignedAsHex(c, dst);
+        } else {
+            StringUtil::builderAppend(*dst, c);
+        }
+    }
+}
+
+} // anonymous namespace
+
+bool Value::asBoolean(bool*) const
+{
+    return false;
+}
+
+bool Value::asDouble(double*) const
+{
+    return false;
+}
+
+bool Value::asInteger(int*) const
+{
+    return false;
+}
+
+bool Value::asString(String*) const
+{
+    return false;
+}
+
+bool Value::asSerialized(String*) const
+{
+    return false;
+}
+
+void Value::writeJSON(StringBuilder* output) const
+{
+    DCHECK(m_type == TypeNull);
+    StringUtil::builderAppend(*output, nullValueString, 4);
+}
+
+std::unique_ptr<Value> Value::clone() const
+{
+    return Value::null();
+}
+
+String Value::serialize()
+{
+    StringBuilder result;
+    StringUtil::builderReserve(result, 512);
+    writeJSON(&result);
+    return StringUtil::builderToString(result);
+}
+
+bool FundamentalValue::asBoolean(bool* output) const
+{
+    if (type() != TypeBoolean)
+        return false;
+    *output = m_boolValue;
+    return true;
+}
+
+bool FundamentalValue::asDouble(double* output) const
+{
+    if (type() == TypeDouble) {
+        *output = m_doubleValue;
+        return true;
+    }
+    if (type() == TypeInteger) {
+        *output = m_integerValue;
+        return true;
+    }
+    return false;
+}
+
+bool FundamentalValue::asInteger(int* output) const
+{
+    if (type() != TypeInteger)
+        return false;
+    *output = m_integerValue;
+    return true;
+}
+
+void FundamentalValue::writeJSON(StringBuilder* output) const
+{
+    DCHECK(type() == TypeBoolean || type() == TypeInteger || type() == TypeDouble);
+    if (type() == TypeBoolean) {
+        if (m_boolValue)
+            StringUtil::builderAppend(*output, trueValueString, 4);
+        else
+            StringUtil::builderAppend(*output, falseValueString, 5);
+    } else if (type() == TypeDouble) {
+        if (!std::isfinite(m_doubleValue)) {
+            StringUtil::builderAppend(*output, nullValueString, 4);
+            return;
+        }
+        StringUtil::builderAppend(*output, StringUtil::fromDouble(m_doubleValue));
+    } else if (type() == TypeInteger) {
+        StringUtil::builderAppend(*output, StringUtil::fromInteger(m_integerValue));
+    }
+}
+
+std::unique_ptr<Value> FundamentalValue::clone() const
+{
+    switch (type()) {
+    case TypeDouble: return FundamentalValue::create(m_doubleValue);
+    case TypeInteger: return FundamentalValue::create(m_integerValue);
+    case TypeBoolean: return FundamentalValue::create(m_boolValue);
+    default:
+        DCHECK(false);
+    }
+    return nullptr;
+}
+
+bool StringValue::asString(String* output) const
+{
+    *output = m_stringValue;
+    return true;
+}
+
+void StringValue::writeJSON(StringBuilder* output) const
+{
+    DCHECK(type() == TypeString);
+    StringUtil::builderAppendQuotedString(*output, m_stringValue);
+}
+
+std::unique_ptr<Value> StringValue::clone() const
+{
+    return StringValue::create(m_stringValue);
+}
+
+bool SerializedValue::asSerialized(String* output) const
+{
+    *output = m_serializedValue;
+    return true;
+}
+
+void SerializedValue::writeJSON(StringBuilder* output) const
+{
+    DCHECK(type() == TypeSerialized);
+    StringUtil::builderAppend(*output, m_serializedValue);
+}
+
+std::unique_ptr<Value> SerializedValue::clone() const
+{
+    return SerializedValue::create(m_serializedValue);
+}
+
+DictionaryValue::~DictionaryValue()
+{
+}
+
+void DictionaryValue::setBoolean(const String& name, bool value)
+{
+    setValue(name, FundamentalValue::create(value));
+}
+
+void DictionaryValue::setInteger(const String& name, int value)
+{
+    setValue(name, FundamentalValue::create(value));
+}
+
+void DictionaryValue::setDouble(const String& name, double value)
+{
+    setValue(name, FundamentalValue::create(value));
+}
+
+void DictionaryValue::setString(const String& name, const String& value)
+{
+    setValue(name, StringValue::create(value));
+}
+
+void DictionaryValue::setValue(const String& name, std::unique_ptr<Value> value)
+{
+    set(name, value);
+}
+
+void DictionaryValue::setObject(const String& name, std::unique_ptr<DictionaryValue> value)
+{
+    set(name, value);
+}
+
+void DictionaryValue::setArray(const String& name, std::unique_ptr<ListValue> value)
+{
+    set(name, value);
+}
+
+bool DictionaryValue::getBoolean(const String& name, bool* output) const
+{
+    protocol::Value* value = get(name);
+    if (!value)
+        return false;
+    return value->asBoolean(output);
+}
+
+bool DictionaryValue::getInteger(const String& name, int* output) const
+{
+    Value* value = get(name);
+    if (!value)
+        return false;
+    return value->asInteger(output);
+}
+
+bool DictionaryValue::getDouble(const String& name, double* output) const
+{
+    Value* value = get(name);
+    if (!value)
+        return false;
+    return value->asDouble(output);
+}
+
+bool DictionaryValue::getString(const String& name, String* output) const
+{
+    protocol::Value* value = get(name);
+    if (!value)
+        return false;
+    return value->asString(output);
+}
+
+DictionaryValue* DictionaryValue::getObject(const String& name) const
+{
+    return DictionaryValue::cast(get(name));
+}
+
+protocol::ListValue* DictionaryValue::getArray(const String& name) const
+{
+    return ListValue::cast(get(name));
+}
+
+protocol::Value* DictionaryValue::get(const String& name) const
+{
+    Dictionary::const_iterator it = m_data.find(name);
+    if (it == m_data.end())
+        return nullptr;
+    return it->second.get();
+}
+
+DictionaryValue::Entry DictionaryValue::at(size_t index) const
+{
+    const String key = m_order[index];
+    return std::make_pair(key, m_data.find(key)->second.get());
+}
+
+bool DictionaryValue::booleanProperty(const String& name, bool defaultValue) const
+{
+    bool result = defaultValue;
+    getBoolean(name, &result);
+    return result;
+}
+
+int DictionaryValue::integerProperty(const String& name, int defaultValue) const
+{
+    int result = defaultValue;
+    getInteger(name, &result);
+    return result;
+}
+
+double DictionaryValue::doubleProperty(const String& name, double defaultValue) const
+{
+    double result = defaultValue;
+    getDouble(name, &result);
+    return result;
+}
+
+void DictionaryValue::remove(const String& name)
+{
+    m_data.erase(name);
+    m_order.erase(std::remove(m_order.begin(), m_order.end(), name), m_order.end());
+}
+
+void DictionaryValue::writeJSON(StringBuilder* output) const
+{
+    StringUtil::builderAppend(*output, '{');
+    for (size_t i = 0; i < m_order.size(); ++i) {
+        Dictionary::const_iterator it = m_data.find(m_order[i]);
+        CHECK(it != m_data.end());
+        if (i)
+            StringUtil::builderAppend(*output, ',');
+        StringUtil::builderAppendQuotedString(*output, it->first);
+        StringUtil::builderAppend(*output, ':');
+        it->second->writeJSON(output);
+    }
+    StringUtil::builderAppend(*output, '}');
+}
+
+std::unique_ptr<Value> DictionaryValue::clone() const
+{
+    std::unique_ptr<DictionaryValue> result = DictionaryValue::create();
+    for (size_t i = 0; i < m_order.size(); ++i) {
+        String key = m_order[i];
+        Dictionary::const_iterator value = m_data.find(key);
+        DCHECK(value != m_data.cend() && value->second);
+        result->setValue(key, value->second->clone());
+    }
+    return std::move(result);
+}
+
+DictionaryValue::DictionaryValue()
+    : Value(TypeObject)
+{
+}
+
+ListValue::~ListValue()
+{
+}
+
+void ListValue::writeJSON(StringBuilder* output) const
+{
+    StringUtil::builderAppend(*output, '[');
+    bool first = true;
+    for (const std::unique_ptr<protocol::Value>& value : m_data) {
+        if (!first)
+            StringUtil::builderAppend(*output, ',');
+        value->writeJSON(output);
+        first = false;
+    }
+    StringUtil::builderAppend(*output, ']');
+}
+
+std::unique_ptr<Value> ListValue::clone() const
+{
+    std::unique_ptr<ListValue> result = ListValue::create();
+    for (const std::unique_ptr<protocol::Value>& value : m_data)
+        result->pushValue(value->clone());
+    return std::move(result);
+}
+
+ListValue::ListValue()
+    : Value(TypeArray)
+{
+}
+
+void ListValue::pushValue(std::unique_ptr<protocol::Value> value)
+{
+    DCHECK(value);
+    m_data.push_back(std::move(value));
+}
+
+protocol::Value* ListValue::at(size_t index)
+{
+    DCHECK_LT(index, m_data.size());
+    return m_data[index].get();
+}
+
+void escapeLatinStringForJSON(const uint8_t* str, unsigned len, StringBuilder* dst)
+{
+    escapeStringForJSONInternal<uint8_t>(str, len, dst);
+}
+
+void escapeWideStringForJSON(const uint16_t* str, unsigned len, StringBuilder* dst)
+{
+    escapeStringForJSONInternal<uint16_t>(str, len, dst);
+}
+
+} // namespace JsDebug
+} // namespace protocol
+
+
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+//#include "Object.h"
+
+namespace JsDebug {
+namespace protocol {
+
+std::unique_ptr<Object> Object::fromValue(protocol::Value* value, ErrorSupport* errors)
+{
+    protocol::DictionaryValue* dictionary = DictionaryValue::cast(value);
+    if (!dictionary) {
+        errors->addError("object expected");
+        return nullptr;
+    }
+    dictionary = static_cast<protocol::DictionaryValue*>(dictionary->clone().release());
+    return std::unique_ptr<Object>(new Object(std::unique_ptr<DictionaryValue>(dictionary)));
+}
+
+std::unique_ptr<protocol::DictionaryValue> Object::toValue() const
+{
+    return DictionaryValue::cast(m_object->clone());
+}
+
+std::unique_ptr<Object> Object::clone() const
+{
+    return std::unique_ptr<Object>(new Object(DictionaryValue::cast(m_object->clone())));
+}
+
+Object::Object(std::unique_ptr<protocol::DictionaryValue> object) : m_object(std::move(object)) { }
+
+Object::~Object() { }
+
+} // namespace JsDebug
+} // namespace protocol
+
+
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+//#include "DispatcherBase.h"
+//#include "Parser.h"
+
+namespace JsDebug {
+namespace protocol {
+
+// static
+DispatchResponse DispatchResponse::OK()
+{
+    DispatchResponse result;
+    result.m_status = kSuccess;
+    result.m_errorCode = kParseError;
+    return result;
+}
+
+// static
+DispatchResponse DispatchResponse::Error(const String& error)
+{
+    DispatchResponse result;
+    result.m_status = kError;
+    result.m_errorCode = kServerError;
+    result.m_errorMessage = error;
+    return result;
+}
+
+// static
+DispatchResponse DispatchResponse::InternalError()
+{
+    DispatchResponse result;
+    result.m_status = kError;
+    result.m_errorCode = kInternalError;
+    result.m_errorMessage = "Internal error";
+    return result;
+}
+
+// static
+DispatchResponse DispatchResponse::InvalidParams(const String& error)
+{
+    DispatchResponse result;
+    result.m_status = kError;
+    result.m_errorCode = kInvalidParams;
+    result.m_errorMessage = error;
+    return result;
+}
+
+// static
+DispatchResponse DispatchResponse::FallThrough()
+{
+    DispatchResponse result;
+    result.m_status = kFallThrough;
+    result.m_errorCode = kParseError;
+    return result;
+}
+
+// static
+const char DispatcherBase::kInvalidParamsString[] = "Invalid parameters";
+
+DispatcherBase::WeakPtr::WeakPtr(DispatcherBase* dispatcher) : m_dispatcher(dispatcher) { }
+
+DispatcherBase::WeakPtr::~WeakPtr()
+{
+    if (m_dispatcher)
+        m_dispatcher->m_weakPtrs.erase(this);
+}
+
+DispatcherBase::Callback::Callback(std::unique_ptr<DispatcherBase::WeakPtr> backendImpl, int callId, int callbackId)
+    : m_backendImpl(std::move(backendImpl))
+    , m_callId(callId)
+    , m_callbackId(callbackId) { }
+
+DispatcherBase::Callback::~Callback() = default;
+
+void DispatcherBase::Callback::dispose()
+{
+    m_backendImpl = nullptr;
+}
+
+void DispatcherBase::Callback::sendIfActive(std::unique_ptr<protocol::DictionaryValue> partialMessage, const DispatchResponse& response)
+{
+    if (!m_backendImpl || !m_backendImpl->get())
+        return;
+    m_backendImpl->get()->sendResponse(m_callId, response, std::move(partialMessage));
+    m_backendImpl = nullptr;
+}
+
+void DispatcherBase::Callback::fallThroughIfActive()
+{
+    if (!m_backendImpl || !m_backendImpl->get())
+        return;
+    m_backendImpl->get()->markFallThrough(m_callbackId);
+    m_backendImpl = nullptr;
+}
+
+DispatcherBase::DispatcherBase(FrontendChannel* frontendChannel)
+    : m_frontendChannel(frontendChannel)
+    , m_lastCallbackId(0)
+    , m_lastCallbackFallThrough(false) { }
+
+DispatcherBase::~DispatcherBase()
+{
+    clearFrontend();
+}
+
+int DispatcherBase::nextCallbackId()
+{
+    m_lastCallbackFallThrough = false;
+    return ++m_lastCallbackId;
+}
+
+void DispatcherBase::markFallThrough(int callbackId)
+{
+    DCHECK(callbackId == m_lastCallbackId);
+    m_lastCallbackFallThrough = true;
+}
+
+void DispatcherBase::sendResponse(int callId, const DispatchResponse& response, std::unique_ptr<protocol::DictionaryValue> result)
+{
+    if (!m_frontendChannel)
+        return;
+    if (response.status() == DispatchResponse::kError) {
+        reportProtocolError(callId, response.errorCode(), response.errorMessage(), nullptr);
+        return;
+    }
+    m_frontendChannel->sendProtocolResponse(callId, InternalResponse::createResponse(callId, std::move(result)));
+}
+
+void DispatcherBase::sendResponse(int callId, const DispatchResponse& response)
+{
+    sendResponse(callId, response, DictionaryValue::create());
+}
+
+namespace {
+
+class ProtocolError : public Serializable {
+public:
+    static std::unique_ptr<ProtocolError> createErrorResponse(int callId, DispatchResponse::ErrorCode code, const String& errorMessage, ErrorSupport* errors)
+    {
+        std::unique_ptr<ProtocolError> protocolError(new ProtocolError(code, errorMessage));
+        protocolError->m_callId = callId;
+        protocolError->m_hasCallId = true;
+        if (errors && errors->hasErrors())
+            protocolError->m_data = errors->errors();
+        return protocolError;
+    }
+
+    static std::unique_ptr<ProtocolError> createErrorNotification(DispatchResponse::ErrorCode code, const String& errorMessage)
+    {
+        return std::unique_ptr<ProtocolError>(new ProtocolError(code, errorMessage));
+    }
+
+    String serialize() override
+    {
+        std::unique_ptr<protocol::DictionaryValue> error = DictionaryValue::create();
+        error->setInteger("code", m_code);
+        error->setString("message", m_errorMessage);
+        if (m_data.length())
+            error->setString("data", m_data);
+        std::unique_ptr<protocol::DictionaryValue> message = DictionaryValue::create();
+        message->setObject("error", std::move(error));
+        if (m_hasCallId)
+            message->setInteger("id", m_callId);
+        return message->serialize();
+    }
+
+    ~ProtocolError() override {}
+
+private:
+    ProtocolError(DispatchResponse::ErrorCode code, const String& errorMessage)
+        : m_code(code)
+        , m_errorMessage(errorMessage)
+    {
+    }
+
+    DispatchResponse::ErrorCode m_code;
+    String m_errorMessage;
+    String m_data;
+    int m_callId = 0;
+    bool m_hasCallId = false;
+};
+
+} // namespace
+
+static void reportProtocolErrorTo(FrontendChannel* frontendChannel, int callId, DispatchResponse::ErrorCode code, const String& errorMessage, ErrorSupport* errors)
+{
+    if (frontendChannel)
+        frontendChannel->sendProtocolResponse(callId, ProtocolError::createErrorResponse(callId, code, errorMessage, errors));
+}
+
+static void reportProtocolErrorTo(FrontendChannel* frontendChannel, DispatchResponse::ErrorCode code, const String& errorMessage)
+{
+    if (frontendChannel)
+        frontendChannel->sendProtocolNotification(ProtocolError::createErrorNotification(code, errorMessage));
+}
+
+void DispatcherBase::reportProtocolError(int callId, DispatchResponse::ErrorCode code, const String& errorMessage, ErrorSupport* errors)
+{
+    reportProtocolErrorTo(m_frontendChannel, callId, code, errorMessage, errors);
+}
+
+void DispatcherBase::clearFrontend()
+{
+    m_frontendChannel = nullptr;
+    for (auto& weak : m_weakPtrs)
+        weak->dispose();
+    m_weakPtrs.clear();
+}
+
+std::unique_ptr<DispatcherBase::WeakPtr> DispatcherBase::weakPtr()
+{
+    std::unique_ptr<DispatcherBase::WeakPtr> weak(new DispatcherBase::WeakPtr(this));
+    m_weakPtrs.insert(weak.get());
+    return weak;
+}
+
+UberDispatcher::UberDispatcher(FrontendChannel* frontendChannel)
+    : m_frontendChannel(frontendChannel)
+    , m_fallThroughForNotFound(false) { }
+
+void UberDispatcher::setFallThroughForNotFound(bool fallThroughForNotFound)
+{
+    m_fallThroughForNotFound = fallThroughForNotFound;
+}
+
+void UberDispatcher::registerBackend(const String& name, std::unique_ptr<protocol::DispatcherBase> dispatcher)
+{
+    m_dispatchers[name] = std::move(dispatcher);
+}
+
+void UberDispatcher::setupRedirects(const HashMap<String, String>& redirects)
+{
+    for (const auto& pair : redirects)
+        m_redirects[pair.first] = pair.second;
+}
+
+DispatchResponse::Status UberDispatcher::dispatch(std::unique_ptr<Value> parsedMessage, int* outCallId, String* outMethod)
+{
+    if (!parsedMessage) {
+        reportProtocolErrorTo(m_frontendChannel, DispatchResponse::kParseError, "Message must be a valid JSON");
+        return DispatchResponse::kError;
+    }
+    std::unique_ptr<protocol::DictionaryValue> messageObject = DictionaryValue::cast(std::move(parsedMessage));
+    if (!messageObject) {
+        reportProtocolErrorTo(m_frontendChannel, DispatchResponse::kInvalidRequest, "Message must be an object");
+        return DispatchResponse::kError;
+    }
+
+    int callId = 0;
+    protocol::Value* callIdValue = messageObject->get("id");
+    bool success = callIdValue && callIdValue->asInteger(&callId);
+    if (outCallId)
+        *outCallId = callId;
+    if (!success) {
+        reportProtocolErrorTo(m_frontendChannel, DispatchResponse::kInvalidRequest, "Message must have integer 'id' property");
+        return DispatchResponse::kError;
+    }
+
+    protocol::Value* methodValue = messageObject->get("method");
+    String method;
+    success = methodValue && methodValue->asString(&method);
+    if (outMethod)
+        *outMethod = method;
+    if (!success) {
+        reportProtocolErrorTo(m_frontendChannel, callId, DispatchResponse::kInvalidRequest, "Message must have string 'method' property", nullptr);
+        return DispatchResponse::kError;
+    }
+
+    HashMap<String, String>::iterator redirectIt = m_redirects.find(method);
+    if (redirectIt != m_redirects.end())
+        method = redirectIt->second;
+
+    size_t dotIndex = StringUtil::find(method, ".");
+    if (dotIndex == StringUtil::kNotFound) {
+        if (m_fallThroughForNotFound)
+            return DispatchResponse::kFallThrough;
+        reportProtocolErrorTo(m_frontendChannel, callId, DispatchResponse::kMethodNotFound, "'" + method + "' wasn't found", nullptr);
+        return DispatchResponse::kError;
+    }
+    String domain = StringUtil::substring(method, 0, dotIndex);
+    auto it = m_dispatchers.find(domain);
+    if (it == m_dispatchers.end()) {
+        if (m_fallThroughForNotFound)
+            return DispatchResponse::kFallThrough;
+        reportProtocolErrorTo(m_frontendChannel, callId, DispatchResponse::kMethodNotFound, "'" + method + "' wasn't found", nullptr);
+        return DispatchResponse::kError;
+    }
+    return it->second->dispatch(callId, method, std::move(messageObject));
+}
+
+bool UberDispatcher::getCommandName(const String& message, String* method, std::unique_ptr<protocol::DictionaryValue>* parsedMessage)
+{
+    std::unique_ptr<protocol::Value> value = StringUtil::parseJSON(message);
+    if (!value) {
+        reportProtocolErrorTo(m_frontendChannel, DispatchResponse::kParseError, "Message must be a valid JSON");
+        return false;
+   }
+
+    protocol::DictionaryValue* object = DictionaryValue::cast(value.get());
+    if (!object) {
+        reportProtocolErrorTo(m_frontendChannel, DispatchResponse::kInvalidRequest, "Message must be an object");
+        return false;
+    }
+
+    if (!object->getString("method", method)) {
+        reportProtocolErrorTo(m_frontendChannel, DispatchResponse::kInvalidRequest, "Message must have string 'method' property");
+        return false;
+    }
+
+    parsedMessage->reset(DictionaryValue::cast(value.release()));
+    return true;
+}
+
+UberDispatcher::~UberDispatcher() = default;
+
+// static
+std::unique_ptr<InternalResponse> InternalResponse::createResponse(int callId, std::unique_ptr<Serializable> params)
+{
+    return std::unique_ptr<InternalResponse>(new InternalResponse(callId, String(), std::move(params)));
+}
+
+// static
+std::unique_ptr<InternalResponse> InternalResponse::createNotification(const String& notification, std::unique_ptr<Serializable> params)
+{
+    return std::unique_ptr<InternalResponse>(new InternalResponse(0, notification, std::move(params)));
+}
+
+String InternalResponse::serialize()
+{
+    std::unique_ptr<DictionaryValue> result = DictionaryValue::create();
+    std::unique_ptr<Serializable> params(m_params ? std::move(m_params) : DictionaryValue::create());
+    if (m_notification.length()) {
+        result->setString("method", m_notification);
+        result->setValue("params", SerializedValue::create(params->serialize()));
+    } else {
+        result->setInteger("id", m_callId);
+        result->setValue("result", SerializedValue::create(params->serialize()));
+    }
+    return result->serialize();
+}
+
+InternalResponse::InternalResponse(int callId, const String& notification, std::unique_ptr<Serializable> params)
+    : m_callId(callId)
+    , m_notification(notification)
+    , m_params(params ? std::move(params) : nullptr)
+{
+}
+
+} // namespace JsDebug
+} // namespace protocol
+
+
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+namespace JsDebug {
+namespace protocol {
+
+namespace {
+
+const int stackLimit = 1000;
+
+enum Token {
+    ObjectBegin,
+    ObjectEnd,
+    ArrayBegin,
+    ArrayEnd,
+    StringLiteral,
+    Number,
+    BoolTrue,
+    BoolFalse,
+    NullToken,
+    ListSeparator,
+    ObjectPairSeparator,
+    InvalidToken,
+};
+
+const char* const nullString = "null";
+const char* const trueString = "true";
+const char* const falseString = "false";
+
+bool isASCII(uint16_t c)
+{
+    return !(c & ~0x7F);
+}
+
+bool isSpaceOrNewLine(uint16_t c)
+{
+    return isASCII(c) && c <= ' ' && (c == ' ' || (c <= 0xD && c >= 0x9));
+}
+
+double charactersToDouble(const uint16_t* characters, size_t length, bool* ok)
+{
+    std::vector<char> buffer;
+    buffer.reserve(length + 1);
+    for (size_t i = 0; i < length; ++i) {
+        if (!isASCII(characters[i])) {
+            *ok = false;
+            return 0;
+        }
+        buffer.push_back(static_cast<char>(characters[i]));
+    }
+    buffer.push_back('\0');
+    return StringUtil::toDouble(buffer.data(), length, ok);
+}
+
+double charactersToDouble(const uint8_t* characters, size_t length, bool* ok)
+{
+    std::string buffer(reinterpret_cast<const char*>(characters), length);
+    return StringUtil::toDouble(buffer.data(), length, ok);
+}
+
+template<typename Char>
+bool parseConstToken(const Char* start, const Char* end, const Char** tokenEnd, const char* token)
+{
+    while (start < end && *token != '\0' && *start++ == *token++) { }
+    if (*token != '\0')
+        return false;
+    *tokenEnd = start;
+    return true;
+}
+
+template<typename Char>
+bool readInt(const Char* start, const Char* end, const Char** tokenEnd, bool canHaveLeadingZeros)
+{
+    if (start == end)
+        return false;
+    bool haveLeadingZero = '0' == *start;
+    int length = 0;
+    while (start < end && '0' <= *start && *start <= '9') {
+        ++start;
+        ++length;
+    }
+    if (!length)
+        return false;
+    if (!canHaveLeadingZeros && length > 1 && haveLeadingZero)
+        return false;
+    *tokenEnd = start;
+    return true;
+}
+
+template<typename Char>
+bool parseNumberToken(const Char* start, const Char* end, const Char** tokenEnd)
+{
+    // We just grab the number here. We validate the size in DecodeNumber.
+    // According to RFC4627, a valid number is: [minus] int [frac] [exp]
+    if (start == end)
+        return false;
+    Char c = *start;
+    if ('-' == c)
+        ++start;
+
+    if (!readInt(start, end, &start, false))
+        return false;
+    if (start == end) {
+        *tokenEnd = start;
+        return true;
+    }
+
+    // Optional fraction part
+    c = *start;
+    if ('.' == c) {
+        ++start;
+        if (!readInt(start, end, &start, true))
+            return false;
+        if (start == end) {
+            *tokenEnd = start;
+            return true;
+        }
+        c = *start;
+    }
+
+    // Optional exponent part
+    if ('e' == c || 'E' == c) {
+        ++start;
+        if (start == end)
+            return false;
+        c = *start;
+        if ('-' == c || '+' == c) {
+            ++start;
+            if (start == end)
+                return false;
+        }
+        if (!readInt(start, end, &start, true))
+            return false;
+    }
+
+    *tokenEnd = start;
+    return true;
+}
+
+template<typename Char>
+bool readHexDigits(const Char* start, const Char* end, const Char** tokenEnd, int digits)
+{
+    if (end - start < digits)
+        return false;
+    for (int i = 0; i < digits; ++i) {
+        Char c = *start++;
+        if (!(('0' <= c && c <= '9') || ('a' <= c && c <= 'f') || ('A' <= c && c <= 'F')))
+            return false;
+    }
+    *tokenEnd = start;
+    return true;
+}
+
+template<typename Char>
+bool parseStringToken(const Char* start, const Char* end, const Char** tokenEnd)
+{
+    while (start < end) {
+        Char c = *start++;
+        if ('\\' == c) {
+	    if (start == end)
+	        return false;
+            c = *start++;
+            // Make sure the escaped char is valid.
+            switch (c) {
+            case 'x':
+                if (!readHexDigits(start, end, &start, 2))
+                    return false;
+                break;
+            case 'u':
+                if (!readHexDigits(start, end, &start, 4))
+                    return false;
+                break;
+            case '\\':
+            case '/':
+            case 'b':
+            case 'f':
+            case 'n':
+            case 'r':
+            case 't':
+            case 'v':
+            case '"':
+                break;
+            default:
+                return false;
+            }
+        } else if ('"' == c) {
+            *tokenEnd = start;
+            return true;
+        }
+    }
+    return false;
+}
+
+template<typename Char>
+bool skipComment(const Char* start, const Char* end, const Char** commentEnd)
+{
+    if (start == end)
+        return false;
+
+    if (*start != '/' || start + 1 >= end)
+        return false;
+    ++start;
+
+    if (*start == '/') {
+        // Single line comment, read to newline.
+        for (++start; start < end; ++start) {
+            if (*start == '\n' || *start == '\r') {
+                *commentEnd = start + 1;
+                return true;
+            }
+        }
+        *commentEnd = end;
+        // Comment reaches end-of-input, which is fine.
+        return true;
+    }
+
+    if (*start == '*') {
+        Char previous = '\0';
+        // Block comment, read until end marker.
+        for (++start; start < end; previous = *start++) {
+            if (previous == '*' && *start == '/') {
+                *commentEnd = start + 1;
+                return true;
+            }
+        }
+        // Block comment must close before end-of-input.
+        return false;
+    }
+
+    return false;
+}
+
+template<typename Char>
+void skipWhitespaceAndComments(const Char* start, const Char* end, const Char** whitespaceEnd)
+{
+    while (start < end) {
+        if (isSpaceOrNewLine(*start)) {
+            ++start;
+        } else if (*start == '/') {
+            const Char* commentEnd;
+            if (!skipComment(start, end, &commentEnd))
+                break;
+            start = commentEnd;
+        } else {
+            break;
+        }
+    }
+    *whitespaceEnd = start;
+}
+
+template<typename Char>
+Token parseToken(const Char* start, const Char* end, const Char** tokenStart, const Char** tokenEnd)
+{
+    skipWhitespaceAndComments(start, end, tokenStart);
+    start = *tokenStart;
+
+    if (start == end)
+        return InvalidToken;
+
+    switch (*start) {
+    case 'n':
+        if (parseConstToken(start, end, tokenEnd, nullString))
+            return NullToken;
+        break;
+    case 't':
+        if (parseConstToken(start, end, tokenEnd, trueString))
+            return BoolTrue;
+        break;
+    case 'f':
+        if (parseConstToken(start, end, tokenEnd, falseString))
+            return BoolFalse;
+        break;
+    case '[':
+        *tokenEnd = start + 1;
+        return ArrayBegin;
+    case ']':
+        *tokenEnd = start + 1;
+        return ArrayEnd;
+    case ',':
+        *tokenEnd = start + 1;
+        return ListSeparator;
+    case '{':
+        *tokenEnd = start + 1;
+        return ObjectBegin;
+    case '}':
+        *tokenEnd = start + 1;
+        return ObjectEnd;
+    case ':':
+        *tokenEnd = start + 1;
+        return ObjectPairSeparator;
+    case '0':
+    case '1':
+    case '2':
+    case '3':
+    case '4':
+    case '5':
+    case '6':
+    case '7':
+    case '8':
+    case '9':
+    case '-':
+        if (parseNumberToken(start, end, tokenEnd))
+            return Number;
+        break;
+    case '"':
+        if (parseStringToken(start + 1, end, tokenEnd))
+            return StringLiteral;
+        break;
+    }
+    return InvalidToken;
+}
+
+template<typename Char>
+int hexToInt(Char c)
+{
+    if ('0' <= c && c <= '9')
+        return c - '0';
+    if ('A' <= c && c <= 'F')
+        return c - 'A' + 10;
+    if ('a' <= c && c <= 'f')
+        return c - 'a' + 10;
+    DCHECK(false);
+    return 0;
+}
+
+template<typename Char>
+bool decodeString(const Char* start, const Char* end, StringBuilder* output)
+{
+    while (start < end) {
+        uint16_t c = *start++;
+        if ('\\' != c) {
+            StringUtil::builderAppend(*output, c);
+            continue;
+        }
+	if (start == end)
+	    return false;
+        c = *start++;
+
+        if (c == 'x') {
+            // \x is not supported.
+            return false;
+        }
+
+        switch (c) {
+        case '"':
+        case '/':
+        case '\\':
+            break;
+        case 'b':
+            c = '\b';
+            break;
+        case 'f':
+            c = '\f';
+            break;
+        case 'n':
+            c = '\n';
+            break;
+        case 'r':
+            c = '\r';
+            break;
+        case 't':
+            c = '\t';
+            break;
+        case 'v':
+            c = '\v';
+            break;
+        case 'u':
+            c = (hexToInt(*start) << 12) +
+                (hexToInt(*(start + 1)) << 8) +
+                (hexToInt(*(start + 2)) << 4) +
+                hexToInt(*(start + 3));
+            start += 4;
+            break;
+        default:
+            return false;
+        }
+        StringUtil::builderAppend(*output, c);
+    }
+    return true;
+}
+
+template<typename Char>
+bool decodeString(const Char* start, const Char* end, String* output)
+{
+    if (start == end) {
+        *output = "";
+        return true;
+    }
+    if (start > end)
+        return false;
+    StringBuilder buffer;
+    StringUtil::builderReserve(buffer, end - start);
+    if (!decodeString(start, end, &buffer))
+        return false;
+    *output = StringUtil::builderToString(buffer);
+    return true;
+}
+
+template<typename Char>
+std::unique_ptr<Value> buildValue(const Char* start, const Char* end, const Char** valueTokenEnd, int depth)
+{
+    if (depth > stackLimit)
+        return nullptr;
+
+    std::unique_ptr<Value> result;
+    const Char* tokenStart;
+    const Char* tokenEnd;
+    Token token = parseToken(start, end, &tokenStart, &tokenEnd);
+    switch (token) {
+    case InvalidToken:
+        return nullptr;
+    case NullToken:
+        result = Value::null();
+        break;
+    case BoolTrue:
+        result = FundamentalValue::create(true);
+        break;
+    case BoolFalse:
+        result = FundamentalValue::create(false);
+        break;
+    case Number: {
+        bool ok;
+        double value = charactersToDouble(tokenStart, tokenEnd - tokenStart, &ok);
+        if (!ok)
+            return nullptr;
+        int number = static_cast<int>(value);
+        if (number == value)
+            result = FundamentalValue::create(number);
+        else
+            result = FundamentalValue::create(value);
+        break;
+    }
+    case StringLiteral: {
+        String value;
+        bool ok = decodeString(tokenStart + 1, tokenEnd - 1, &value);
+        if (!ok)
+            return nullptr;
+        result = StringValue::create(value);
+        break;
+    }
+    case ArrayBegin: {
+        std::unique_ptr<ListValue> array = ListValue::create();
+        start = tokenEnd;
+        token = parseToken(start, end, &tokenStart, &tokenEnd);
+        while (token != ArrayEnd) {
+            std::unique_ptr<Value> arrayNode = buildValue(start, end, &tokenEnd, depth + 1);
+            if (!arrayNode)
+                return nullptr;
+            array->pushValue(std::move(arrayNode));
+
+            // After a list value, we expect a comma or the end of the list.
+            start = tokenEnd;
+            token = parseToken(start, end, &tokenStart, &tokenEnd);
+            if (token == ListSeparator) {
+                start = tokenEnd;
+                token = parseToken(start, end, &tokenStart, &tokenEnd);
+                if (token == ArrayEnd)
+                    return nullptr;
+            } else if (token != ArrayEnd) {
+                // Unexpected value after list value. Bail out.
+                return nullptr;
+            }
+        }
+        if (token != ArrayEnd)
+            return nullptr;
+        result = std::move(array);
+        break;
+    }
+    case ObjectBegin: {
+        std::unique_ptr<DictionaryValue> object = DictionaryValue::create();
+        start = tokenEnd;
+        token = parseToken(start, end, &tokenStart, &tokenEnd);
+        while (token != ObjectEnd) {
+            if (token != StringLiteral)
+                return nullptr;
+            String key;
+            if (!decodeString(tokenStart + 1, tokenEnd - 1, &key))
+                return nullptr;
+            start = tokenEnd;
+
+            token = parseToken(start, end, &tokenStart, &tokenEnd);
+            if (token != ObjectPairSeparator)
+                return nullptr;
+            start = tokenEnd;
+
+            std::unique_ptr<Value> value = buildValue(start, end, &tokenEnd, depth + 1);
+            if (!value)
+                return nullptr;
+            object->setValue(key, std::move(value));
+            start = tokenEnd;
+
+            // After a key/value pair, we expect a comma or the end of the
+            // object.
+            token = parseToken(start, end, &tokenStart, &tokenEnd);
+            if (token == ListSeparator) {
+                start = tokenEnd;
+                token = parseToken(start, end, &tokenStart, &tokenEnd);
+                if (token == ObjectEnd)
+                    return nullptr;
+            } else if (token != ObjectEnd) {
+                // Unexpected value after last object value. Bail out.
+                return nullptr;
+            }
+        }
+        if (token != ObjectEnd)
+            return nullptr;
+        result = std::move(object);
+        break;
+    }
+
+    default:
+        // We got a token that's not a value.
+        return nullptr;
+    }
+
+    skipWhitespaceAndComments(tokenEnd, end, valueTokenEnd);
+    return result;
+}
+
+template<typename Char>
+std::unique_ptr<Value> parseJSONInternal(const Char* start, unsigned length)
+{
+    const Char* end = start + length;
+    const Char *tokenEnd;
+    std::unique_ptr<Value> value = buildValue(start, end, &tokenEnd, 0);
+    if (!value || tokenEnd != end)
+        return nullptr;
+    return value;
+}
+
+} // anonymous namespace
+
+std::unique_ptr<Value> parseJSONCharacters(const uint16_t* characters, unsigned length)
+{
+    return parseJSONInternal<uint16_t>(characters, length);
+}
+
+std::unique_ptr<Value> parseJSONCharacters(const uint8_t* characters, unsigned length)
+{
+    return parseJSONInternal<uint8_t>(characters, length);
+}
+
+} // namespace JsDebug
+} // namespace protocol

--- a/lib/Debug.Protocol/Generated/protocol/Protocol.h
+++ b/lib/Debug.Protocol/Generated/protocol/Protocol.h
@@ -1,0 +1,945 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef JsDebug_protocol_Collections_h
+#define JsDebug_protocol_Collections_h
+
+#include "protocol/Forward.h"
+#include <cstddef>
+
+#if defined(__APPLE__) && !defined(_LIBCPP_VERSION)
+#include <map>
+#include <set>
+
+namespace JsDebug {
+namespace protocol {
+
+template <class Key, class T> using HashMap = std::map<Key, T>;
+template <class Key> using HashSet = std::set<Key>;
+
+} // namespace JsDebug
+} // namespace protocol
+
+#else
+#include <unordered_map>
+#include <unordered_set>
+
+namespace JsDebug {
+namespace protocol {
+
+template <class Key, class T> using HashMap = std::unordered_map<Key, T>;
+template <class Key> using HashSet = std::unordered_set<Key>;
+
+} // namespace JsDebug
+} // namespace protocol
+
+#endif // defined(__APPLE__) && !defined(_LIBCPP_VERSION)
+
+#endif // !defined(JsDebug_protocol_Collections_h)
+
+
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef JsDebug_protocol_ErrorSupport_h
+#define JsDebug_protocol_ErrorSupport_h
+
+//#include "Forward.h"
+
+namespace JsDebug {
+namespace protocol {
+
+class  ErrorSupport {
+public:
+    ErrorSupport();
+    ~ErrorSupport();
+
+    void push();
+    void setName(const char*);
+    void setName(const String&);
+    void pop();
+    void addError(const char*);
+    void addError(const String&);
+    bool hasErrors();
+    String errors();
+
+private:
+    std::vector<String> m_path;
+    std::vector<String> m_errors;
+};
+
+} // namespace JsDebug
+} // namespace protocol
+
+#endif // !defined(JsDebug_protocol_ErrorSupport_h)
+
+
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef JsDebug_protocol_Values_h
+#define JsDebug_protocol_Values_h
+
+//#include "Allocator.h"
+//#include "Collections.h"
+//#include "Forward.h"
+
+namespace JsDebug {
+namespace protocol {
+
+class ListValue;
+class DictionaryValue;
+class Value;
+
+class  Value : public Serializable {
+    PROTOCOL_DISALLOW_COPY(Value);
+public:
+    virtual ~Value() override { }
+
+    static std::unique_ptr<Value> null()
+    {
+        return std::unique_ptr<Value>(new Value());
+    }
+
+    enum ValueType {
+        TypeNull = 0,
+        TypeBoolean,
+        TypeInteger,
+        TypeDouble,
+        TypeString,
+        TypeObject,
+        TypeArray,
+        TypeSerialized
+    };
+
+    ValueType type() const { return m_type; }
+
+    bool isNull() const { return m_type == TypeNull; }
+
+    virtual bool asBoolean(bool* output) const;
+    virtual bool asDouble(double* output) const;
+    virtual bool asInteger(int* output) const;
+    virtual bool asString(String* output) const;
+    virtual bool asSerialized(String* output) const;
+
+    virtual void writeJSON(StringBuilder* output) const;
+    virtual std::unique_ptr<Value> clone() const;
+    String serialize() override;
+
+protected:
+    Value() : m_type(TypeNull) { }
+    explicit Value(ValueType type) : m_type(type) { }
+
+private:
+    friend class DictionaryValue;
+    friend class ListValue;
+
+    ValueType m_type;
+};
+
+class  FundamentalValue : public Value {
+public:
+    static std::unique_ptr<FundamentalValue> create(bool value)
+    {
+        return std::unique_ptr<FundamentalValue>(new FundamentalValue(value));
+    }
+
+    static std::unique_ptr<FundamentalValue> create(int value)
+    {
+        return std::unique_ptr<FundamentalValue>(new FundamentalValue(value));
+    }
+
+    static std::unique_ptr<FundamentalValue> create(double value)
+    {
+        return std::unique_ptr<FundamentalValue>(new FundamentalValue(value));
+    }
+
+    bool asBoolean(bool* output) const override;
+    bool asDouble(double* output) const override;
+    bool asInteger(int* output) const override;
+    void writeJSON(StringBuilder* output) const override;
+    std::unique_ptr<Value> clone() const override;
+
+private:
+    explicit FundamentalValue(bool value) : Value(TypeBoolean), m_boolValue(value) { }
+    explicit FundamentalValue(int value) : Value(TypeInteger), m_integerValue(value) { }
+    explicit FundamentalValue(double value) : Value(TypeDouble), m_doubleValue(value) { }
+
+    union {
+        bool m_boolValue;
+        double m_doubleValue;
+        int m_integerValue;
+    };
+};
+
+class  StringValue : public Value {
+public:
+    static std::unique_ptr<StringValue> create(const String& value)
+    {
+        return std::unique_ptr<StringValue>(new StringValue(value));
+    }
+
+    static std::unique_ptr<StringValue> create(const char* value)
+    {
+        return std::unique_ptr<StringValue>(new StringValue(value));
+    }
+
+    bool asString(String* output) const override;
+    void writeJSON(StringBuilder* output) const override;
+    std::unique_ptr<Value> clone() const override;
+
+private:
+    explicit StringValue(const String& value) : Value(TypeString), m_stringValue(value) { }
+    explicit StringValue(const char* value) : Value(TypeString), m_stringValue(value) { }
+
+    String m_stringValue;
+};
+
+class  SerializedValue : public Value {
+public:
+    static std::unique_ptr<SerializedValue> create(const String& value)
+    {
+        return std::unique_ptr<SerializedValue>(new SerializedValue(value));
+    }
+
+    bool asSerialized(String* output) const override;
+    void writeJSON(StringBuilder* output) const override;
+    std::unique_ptr<Value> clone() const override;
+
+private:
+    explicit SerializedValue(const String& value) : Value(TypeSerialized), m_serializedValue(value) { }
+
+    String m_serializedValue;
+};
+
+class  DictionaryValue : public Value {
+public:
+    using Entry = std::pair<String, Value*>;
+    static std::unique_ptr<DictionaryValue> create()
+    {
+        return std::unique_ptr<DictionaryValue>(new DictionaryValue());
+    }
+
+    static DictionaryValue* cast(Value* value)
+    {
+        if (!value || value->type() != TypeObject)
+            return nullptr;
+        return static_cast<DictionaryValue*>(value);
+    }
+
+    static std::unique_ptr<DictionaryValue> cast(std::unique_ptr<Value> value)
+    {
+        return std::unique_ptr<DictionaryValue>(DictionaryValue::cast(value.release()));
+    }
+
+    void writeJSON(StringBuilder* output) const override;
+    std::unique_ptr<Value> clone() const override;
+
+    size_t size() const { return m_data.size(); }
+
+    void setBoolean(const String& name, bool);
+    void setInteger(const String& name, int);
+    void setDouble(const String& name, double);
+    void setString(const String& name, const String&);
+    void setValue(const String& name, std::unique_ptr<Value>);
+    void setObject(const String& name, std::unique_ptr<DictionaryValue>);
+    void setArray(const String& name, std::unique_ptr<ListValue>);
+
+    bool getBoolean(const String& name, bool* output) const;
+    bool getInteger(const String& name, int* output) const;
+    bool getDouble(const String& name, double* output) const;
+    bool getString(const String& name, String* output) const;
+
+    DictionaryValue* getObject(const String& name) const;
+    ListValue* getArray(const String& name) const;
+    Value* get(const String& name) const;
+    Entry at(size_t index) const;
+
+    bool booleanProperty(const String& name, bool defaultValue) const;
+    int integerProperty(const String& name, int defaultValue) const;
+    double doubleProperty(const String& name, double defaultValue) const;
+    void remove(const String& name);
+
+    ~DictionaryValue() override;
+
+private:
+    DictionaryValue();
+    template<typename T>
+    void set(const String& key, std::unique_ptr<T>& value)
+    {
+        DCHECK(value);
+        bool isNew = m_data.find(key) == m_data.end();
+        m_data[key] = std::move(value);
+        if (isNew)
+            m_order.push_back(key);
+    }
+
+    using Dictionary = protocol::HashMap<String, std::unique_ptr<Value>>;
+    Dictionary m_data;
+    std::vector<String> m_order;
+};
+
+class  ListValue : public Value {
+public:
+    static std::unique_ptr<ListValue> create()
+    {
+        return std::unique_ptr<ListValue>(new ListValue());
+    }
+
+    static ListValue* cast(Value* value)
+    {
+        if (!value || value->type() != TypeArray)
+            return nullptr;
+        return static_cast<ListValue*>(value);
+    }
+
+    static std::unique_ptr<ListValue> cast(std::unique_ptr<Value> value)
+    {
+        return std::unique_ptr<ListValue>(ListValue::cast(value.release()));
+    }
+
+    ~ListValue() override;
+
+    void writeJSON(StringBuilder* output) const override;
+    std::unique_ptr<Value> clone() const override;
+
+    void pushValue(std::unique_ptr<Value>);
+
+    Value* at(size_t index);
+    size_t size() const { return m_data.size(); }
+
+private:
+    ListValue();
+    std::vector<std::unique_ptr<Value>> m_data;
+};
+
+void escapeLatinStringForJSON(const uint8_t* str, unsigned len, StringBuilder* dst);
+void escapeWideStringForJSON(const uint16_t* str, unsigned len, StringBuilder* dst);
+
+} // namespace JsDebug
+} // namespace protocol
+
+#endif // JsDebug_protocol_Values_h
+
+
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef JsDebug_protocol_Object_h
+#define JsDebug_protocol_Object_h
+
+//#include "ErrorSupport.h"
+//#include "Forward.h"
+//#include "Values.h"
+
+namespace JsDebug {
+namespace protocol {
+
+class  Object {
+public:
+    static std::unique_ptr<Object> fromValue(protocol::Value*, ErrorSupport*);
+    ~Object();
+
+    std::unique_ptr<protocol::DictionaryValue> toValue() const;
+    std::unique_ptr<Object> clone() const;
+private:
+    explicit Object(std::unique_ptr<protocol::DictionaryValue>);
+    std::unique_ptr<protocol::DictionaryValue> m_object;
+};
+
+} // namespace JsDebug
+} // namespace protocol
+
+#endif // !defined(JsDebug_protocol_Object_h)
+
+
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef JsDebug_protocol_ValueConversions_h
+#define JsDebug_protocol_ValueConversions_h
+
+//#include "ErrorSupport.h"
+//#include "Forward.h"
+//#include "Values.h"
+
+namespace JsDebug {
+namespace protocol {
+
+template<typename T>
+struct ValueConversions {
+    static std::unique_ptr<T> fromValue(protocol::Value* value, ErrorSupport* errors)
+    {
+        return T::fromValue(value, errors);
+    }
+
+    static std::unique_ptr<protocol::Value> toValue(T* value)
+    {
+        return value->toValue();
+    }
+
+    static std::unique_ptr<protocol::Value> toValue(const std::unique_ptr<T>& value)
+    {
+        return value->toValue();
+    }
+};
+
+template<>
+struct ValueConversions<bool> {
+    static bool fromValue(protocol::Value* value, ErrorSupport* errors)
+    {
+        bool result = false;
+        bool success = value ? value->asBoolean(&result) : false;
+        if (!success)
+            errors->addError("boolean value expected");
+        return result;
+    }
+
+    static std::unique_ptr<protocol::Value> toValue(bool value)
+    {
+        return FundamentalValue::create(value);
+    }
+};
+
+template<>
+struct ValueConversions<int> {
+    static int fromValue(protocol::Value* value, ErrorSupport* errors)
+    {
+        int result = 0;
+        bool success = value ? value->asInteger(&result) : false;
+        if (!success)
+            errors->addError("integer value expected");
+        return result;
+    }
+
+    static std::unique_ptr<protocol::Value> toValue(int value)
+    {
+        return FundamentalValue::create(value);
+    }
+};
+
+template<>
+struct ValueConversions<double> {
+    static double fromValue(protocol::Value* value, ErrorSupport* errors)
+    {
+        double result = 0;
+        bool success = value ? value->asDouble(&result) : false;
+        if (!success)
+            errors->addError("double value expected");
+        return result;
+    }
+
+    static std::unique_ptr<protocol::Value> toValue(double value)
+    {
+        return FundamentalValue::create(value);
+    }
+};
+
+template<>
+struct ValueConversions<String> {
+    static String fromValue(protocol::Value* value, ErrorSupport* errors)
+    {
+        String result;
+        bool success = value ? value->asString(&result) : false;
+        if (!success)
+            errors->addError("string value expected");
+        return result;
+    }
+
+    static std::unique_ptr<protocol::Value> toValue(const String& value)
+    {
+        return StringValue::create(value);
+    }
+};
+
+template<>
+struct ValueConversions<Value> {
+    static std::unique_ptr<Value> fromValue(protocol::Value* value, ErrorSupport* errors)
+    {
+        bool success = !!value;
+        if (!success) {
+            errors->addError("value expected");
+            return nullptr;
+        }
+        return value->clone();
+    }
+
+    static std::unique_ptr<protocol::Value> toValue(Value* value)
+    {
+        return value->clone();
+    }
+
+    static std::unique_ptr<protocol::Value> toValue(const std::unique_ptr<Value>& value)
+    {
+        return value->clone();
+    }
+};
+
+template<>
+struct ValueConversions<DictionaryValue> {
+    static std::unique_ptr<DictionaryValue> fromValue(protocol::Value* value, ErrorSupport* errors)
+    {
+        bool success = value && value->type() == protocol::Value::TypeObject;
+        if (!success)
+            errors->addError("object expected");
+        return DictionaryValue::cast(value->clone());
+    }
+
+    static std::unique_ptr<protocol::Value> toValue(DictionaryValue* value)
+    {
+        return value->clone();
+    }
+
+    static std::unique_ptr<protocol::Value> toValue(const std::unique_ptr<DictionaryValue>& value)
+    {
+        return value->clone();
+    }
+};
+
+template<>
+struct ValueConversions<ListValue> {
+    static std::unique_ptr<ListValue> fromValue(protocol::Value* value, ErrorSupport* errors)
+    {
+        bool success = value && value->type() == protocol::Value::TypeArray;
+        if (!success)
+            errors->addError("list expected");
+        return ListValue::cast(value->clone());
+    }
+
+    static std::unique_ptr<protocol::Value> toValue(ListValue* value)
+    {
+        return value->clone();
+    }
+
+    static std::unique_ptr<protocol::Value> toValue(const std::unique_ptr<ListValue>& value)
+    {
+        return value->clone();
+    }
+};
+
+} // namespace JsDebug
+} // namespace protocol
+
+#endif // !defined(JsDebug_protocol_ValueConversions_h)
+
+
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef JsDebug_protocol_Maybe_h
+#define JsDebug_protocol_Maybe_h
+
+//#include "Forward.h"
+
+namespace JsDebug {
+namespace protocol {
+
+template<typename T>
+class Maybe {
+public:
+    Maybe() : m_value() { }
+    Maybe(std::unique_ptr<T> value) : m_value(std::move(value)) { }
+    Maybe(Maybe&& other) : m_value(std::move(other.m_value)) { }
+    void operator=(std::unique_ptr<T> value) { m_value = std::move(value); }
+    T* fromJust() const { DCHECK(m_value); return m_value.get(); }
+    T* fromMaybe(T* defaultValue) const { return m_value ? m_value.get() : defaultValue; }
+    bool isJust() const { return !!m_value; }
+    std::unique_ptr<T> takeJust() { DCHECK(m_value); return std::move(m_value); }
+private:
+    std::unique_ptr<T> m_value;
+};
+
+template<typename T>
+class MaybeBase {
+public:
+    MaybeBase() : m_isJust(false) { }
+    MaybeBase(T value) : m_isJust(true), m_value(value) { }
+    MaybeBase(MaybeBase&& other) : m_isJust(other.m_isJust), m_value(std::move(other.m_value)) { }
+    void operator=(T value) { m_value = value; m_isJust = true; }
+    T fromJust() const { DCHECK(m_isJust); return m_value; }
+    T fromMaybe(const T& defaultValue) const { return m_isJust ? m_value : defaultValue; }
+    bool isJust() const { return m_isJust; }
+    T takeJust() { DCHECK(m_isJust); return m_value; }
+
+protected:
+    bool m_isJust;
+    T m_value;
+};
+
+template<>
+class Maybe<bool> : public MaybeBase<bool> {
+public:
+    Maybe() { }
+    Maybe(bool value) : MaybeBase(value) { }
+    Maybe(Maybe&& other) : MaybeBase(std::move(other)) { }
+    using MaybeBase::operator=;
+};
+
+template<>
+class Maybe<int> : public MaybeBase<int> {
+public:
+    Maybe() { }
+    Maybe(int value) : MaybeBase(value) { }
+    Maybe(Maybe&& other) : MaybeBase(std::move(other)) { }
+    using MaybeBase::operator=;
+};
+
+template<>
+class Maybe<double> : public MaybeBase<double> {
+public:
+    Maybe() { }
+    Maybe(double value) : MaybeBase(value) { }
+    Maybe(Maybe&& other) : MaybeBase(std::move(other)) { }
+    using MaybeBase::operator=;
+};
+
+template<>
+class Maybe<String> : public MaybeBase<String> {
+public:
+    Maybe() { }
+    Maybe(const String& value) : MaybeBase(value) { }
+    Maybe(Maybe&& other) : MaybeBase(std::move(other)) { }
+    using MaybeBase::operator=;
+};
+
+} // namespace JsDebug
+} // namespace protocol
+
+#endif // !defined(JsDebug_protocol_Maybe_h)
+
+
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef JsDebug_protocol_Array_h
+#define JsDebug_protocol_Array_h
+
+//#include "ErrorSupport.h"
+//#include "Forward.h"
+//#include "ValueConversions.h"
+//#include "Values.h"
+
+namespace JsDebug {
+namespace protocol {
+
+template<typename T>
+class Array {
+public:
+    static std::unique_ptr<Array<T>> create()
+    {
+        return std::unique_ptr<Array<T>>(new Array<T>());
+    }
+
+    static std::unique_ptr<Array<T>> fromValue(protocol::Value* value, ErrorSupport* errors)
+    {
+        protocol::ListValue* array = ListValue::cast(value);
+        if (!array) {
+            errors->addError("array expected");
+            return nullptr;
+        }
+        std::unique_ptr<Array<T>> result(new Array<T>());
+        errors->push();
+        for (size_t i = 0; i < array->size(); ++i) {
+            errors->setName(StringUtil::fromInteger(i));
+            std::unique_ptr<T> item = ValueConversions<T>::fromValue(array->at(i), errors);
+            result->m_vector.push_back(std::move(item));
+        }
+        errors->pop();
+        if (errors->hasErrors())
+            return nullptr;
+        return result;
+    }
+
+    void addItem(std::unique_ptr<T> value)
+    {
+        m_vector.push_back(std::move(value));
+    }
+
+    size_t length()
+    {
+        return m_vector.size();
+    }
+
+    T* get(size_t index)
+    {
+        return m_vector[index].get();
+    }
+
+    std::unique_ptr<protocol::ListValue> toValue()
+    {
+        std::unique_ptr<protocol::ListValue> result = ListValue::create();
+        for (auto& item : m_vector)
+            result->pushValue(ValueConversions<T>::toValue(item));
+        return result;
+    }
+
+private:
+    std::vector<std::unique_ptr<T>> m_vector;
+};
+
+template<typename T>
+class ArrayBase {
+public:
+    static std::unique_ptr<Array<T>> create()
+    {
+        return std::unique_ptr<Array<T>>(new Array<T>());
+    }
+
+    static std::unique_ptr<Array<T>> fromValue(protocol::Value* value, ErrorSupport* errors)
+    {
+        protocol::ListValue* array = ListValue::cast(value);
+        if (!array) {
+            errors->addError("array expected");
+            return nullptr;
+        }
+        errors->push();
+        std::unique_ptr<Array<T>> result(new Array<T>());
+        for (size_t i = 0; i < array->size(); ++i) {
+            errors->setName(StringUtil::fromInteger(i));
+            T item = ValueConversions<T>::fromValue(array->at(i), errors);
+            result->m_vector.push_back(item);
+        }
+        errors->pop();
+        if (errors->hasErrors())
+            return nullptr;
+        return result;
+    }
+
+    void addItem(const T& value)
+    {
+        m_vector.push_back(value);
+    }
+
+    size_t length()
+    {
+        return m_vector.size();
+    }
+
+    T get(size_t index)
+    {
+        return m_vector[index];
+    }
+
+    std::unique_ptr<protocol::ListValue> toValue()
+    {
+        std::unique_ptr<protocol::ListValue> result = ListValue::create();
+        for (auto& item : m_vector)
+            result->pushValue(ValueConversions<T>::toValue(item));
+        return result;
+    }
+
+private:
+    std::vector<T> m_vector;
+};
+
+template<> class Array<String> : public ArrayBase<String> {};
+template<> class Array<int> : public ArrayBase<int> {};
+template<> class Array<double> : public ArrayBase<double> {};
+template<> class Array<bool> : public ArrayBase<bool> {};
+
+} // namespace JsDebug
+} // namespace protocol
+
+#endif // !defined(JsDebug_protocol_Array_h)
+
+
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef JsDebug_protocol_DispatcherBase_h
+#define JsDebug_protocol_DispatcherBase_h
+
+//#include "Collections.h"
+//#include "ErrorSupport.h"
+//#include "Forward.h"
+//#include "Values.h"
+
+namespace JsDebug {
+namespace protocol {
+
+class WeakPtr;
+
+class  DispatchResponse {
+public:
+    enum Status {
+        kSuccess = 0,
+        kError = 1,
+        kFallThrough = 2,
+        kAsync = 3
+    };
+
+    enum ErrorCode {
+        kParseError = -32700,
+        kInvalidRequest = -32600,
+        kMethodNotFound = -32601,
+        kInvalidParams = -32602,
+        kInternalError = -32603,
+        kServerError = -32000,
+    };
+
+    Status status() const { return m_status; }
+    const String& errorMessage() const { return m_errorMessage; }
+    ErrorCode errorCode() const { return m_errorCode; }
+    bool isSuccess() const { return m_status == kSuccess; }
+
+    static DispatchResponse OK();
+    static DispatchResponse Error(const String&);
+    static DispatchResponse InternalError();
+    static DispatchResponse InvalidParams(const String&);
+    static DispatchResponse FallThrough();
+
+private:
+    Status m_status;
+    String m_errorMessage;
+    ErrorCode m_errorCode;
+};
+
+class  DispatcherBase {
+    PROTOCOL_DISALLOW_COPY(DispatcherBase);
+public:
+    static const char kInvalidParamsString[];
+    class  WeakPtr {
+    public:
+        explicit WeakPtr(DispatcherBase*);
+        ~WeakPtr();
+        DispatcherBase* get() { return m_dispatcher; }
+        void dispose() { m_dispatcher = nullptr; }
+
+    private:
+        DispatcherBase* m_dispatcher;
+    };
+
+    class  Callback {
+    public:
+        Callback(std::unique_ptr<WeakPtr> backendImpl, int callId, int callbackId);
+        virtual ~Callback();
+        void dispose();
+
+    protected:
+        void sendIfActive(std::unique_ptr<protocol::DictionaryValue> partialMessage, const DispatchResponse& response);
+        void fallThroughIfActive();
+
+    private:
+        std::unique_ptr<WeakPtr> m_backendImpl;
+        int m_callId;
+        int m_callbackId;
+    };
+
+    explicit DispatcherBase(FrontendChannel*);
+    virtual ~DispatcherBase();
+
+    virtual DispatchResponse::Status dispatch(int callId, const String& method, std::unique_ptr<protocol::DictionaryValue> messageObject) = 0;
+
+    void sendResponse(int callId, const DispatchResponse&, std::unique_ptr<protocol::DictionaryValue> result);
+    void sendResponse(int callId, const DispatchResponse&);
+
+    void reportProtocolError(int callId, DispatchResponse::ErrorCode, const String& errorMessage, ErrorSupport* errors);
+    void clearFrontend();
+
+    std::unique_ptr<WeakPtr> weakPtr();
+
+    int nextCallbackId();
+    void markFallThrough(int callbackId);
+    bool lastCallbackFallThrough() { return m_lastCallbackFallThrough; }
+
+private:
+    FrontendChannel* m_frontendChannel;
+    protocol::HashSet<WeakPtr*> m_weakPtrs;
+    int m_lastCallbackId;
+    bool m_lastCallbackFallThrough;
+};
+
+class  UberDispatcher {
+    PROTOCOL_DISALLOW_COPY(UberDispatcher);
+public:
+    explicit UberDispatcher(FrontendChannel*);
+    void registerBackend(const String& name, std::unique_ptr<protocol::DispatcherBase>);
+    void setupRedirects(const HashMap<String, String>&);
+    DispatchResponse::Status dispatch(std::unique_ptr<Value> message, int* callId = nullptr, String* method = nullptr);
+    FrontendChannel* channel() { return m_frontendChannel; }
+    bool fallThroughForNotFound() { return m_fallThroughForNotFound; }
+    void setFallThroughForNotFound(bool);
+    bool getCommandName(const String& message, String* method, std::unique_ptr<protocol::DictionaryValue>* parsedMessage);
+    virtual ~UberDispatcher();
+
+private:
+    FrontendChannel* m_frontendChannel;
+    bool m_fallThroughForNotFound;
+    HashMap<String, String> m_redirects;
+    protocol::HashMap<String, std::unique_ptr<protocol::DispatcherBase>> m_dispatchers;
+};
+
+class InternalResponse : public Serializable {
+    PROTOCOL_DISALLOW_COPY(InternalResponse);
+public:
+    static std::unique_ptr<InternalResponse> createResponse(int callId, std::unique_ptr<Serializable> params);
+    static std::unique_ptr<InternalResponse> createNotification(const String& notification, std::unique_ptr<Serializable> params = nullptr);
+
+    String serialize() override;
+
+    ~InternalResponse() override {}
+
+private:
+    InternalResponse(int callId, const String& notification, std::unique_ptr<Serializable> params);
+
+    int m_callId;
+    String m_notification;
+    std::unique_ptr<Serializable> m_params;
+};
+
+class InternalRawNotification : public Serializable {
+public:
+    static std::unique_ptr<InternalRawNotification> create(const String& notification)
+    {
+        return std::unique_ptr<InternalRawNotification>(new InternalRawNotification(notification));
+    }
+    ~InternalRawNotification() override {}
+
+    String serialize() override
+    {
+        return m_notification;
+    }
+
+private:
+  explicit InternalRawNotification(const String& notification)
+    : m_notification(notification)
+  {
+  }
+
+  String m_notification;
+};
+
+} // namespace JsDebug
+} // namespace protocol
+
+#endif // !defined(JsDebug_protocol_DispatcherBase_h)
+
+
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef JsDebug_protocol_Parser_h
+#define JsDebug_protocol_Parser_h
+
+//#include "Forward.h"
+//#include "Values.h"
+
+namespace JsDebug {
+namespace protocol {
+
+ std::unique_ptr<Value> parseJSONCharacters(const uint8_t*, unsigned);
+ std::unique_ptr<Value> parseJSONCharacters(const uint16_t*, unsigned);
+
+} // namespace JsDebug
+} // namespace protocol
+
+#endif // !defined(JsDebug_protocol_Parser_h)

--- a/lib/Debug.Protocol/Generated/protocol/Runtime.cpp
+++ b/lib/Debug.Protocol/Generated/protocol/Runtime.cpp
@@ -1,0 +1,1780 @@
+// This file is generated
+
+// Copyright (c) 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "protocol/Runtime.h"
+
+#include "protocol/Protocol.h"
+
+namespace JsDebug {
+namespace protocol {
+namespace Runtime {
+
+// ------------- Enum values from types.
+
+const char Metainfo::domainName[] = "Runtime";
+const char Metainfo::commandPrefix[] = "Runtime.";
+const char Metainfo::version[] = "1.2";
+
+namespace UnserializableValueEnum {
+const char Infinity[] = "Infinity";
+const char NaN[] = "NaN";
+const char NegativeInfinity[] = "-Infinity";
+const char Negative0[] = "-0";
+} // namespace UnserializableValueEnum
+
+const char* RemoteObject::TypeEnum::Object = "object";
+const char* RemoteObject::TypeEnum::Function = "function";
+const char* RemoteObject::TypeEnum::Undefined = "undefined";
+const char* RemoteObject::TypeEnum::String = "string";
+const char* RemoteObject::TypeEnum::Number = "number";
+const char* RemoteObject::TypeEnum::Boolean = "boolean";
+const char* RemoteObject::TypeEnum::Symbol = "symbol";
+
+const char* RemoteObject::SubtypeEnum::Array = "array";
+const char* RemoteObject::SubtypeEnum::Null = "null";
+const char* RemoteObject::SubtypeEnum::Node = "node";
+const char* RemoteObject::SubtypeEnum::Regexp = "regexp";
+const char* RemoteObject::SubtypeEnum::Date = "date";
+const char* RemoteObject::SubtypeEnum::Map = "map";
+const char* RemoteObject::SubtypeEnum::Set = "set";
+const char* RemoteObject::SubtypeEnum::Iterator = "iterator";
+const char* RemoteObject::SubtypeEnum::Generator = "generator";
+const char* RemoteObject::SubtypeEnum::Error = "error";
+const char* RemoteObject::SubtypeEnum::Proxy = "proxy";
+const char* RemoteObject::SubtypeEnum::Promise = "promise";
+const char* RemoteObject::SubtypeEnum::Typedarray = "typedarray";
+
+std::unique_ptr<RemoteObject> RemoteObject::fromValue(protocol::Value* value, ErrorSupport* errors)
+{
+    if (!value || value->type() != protocol::Value::TypeObject) {
+        errors->addError("object expected");
+        return nullptr;
+    }
+
+    std::unique_ptr<RemoteObject> result(new RemoteObject());
+    protocol::DictionaryValue* object = DictionaryValue::cast(value);
+    errors->push();
+    protocol::Value* typeValue = object->get("type");
+    errors->setName("type");
+    result->m_type = ValueConversions<String>::fromValue(typeValue, errors);
+    protocol::Value* subtypeValue = object->get("subtype");
+    if (subtypeValue) {
+        errors->setName("subtype");
+        result->m_subtype = ValueConversions<String>::fromValue(subtypeValue, errors);
+    }
+    protocol::Value* classNameValue = object->get("className");
+    if (classNameValue) {
+        errors->setName("className");
+        result->m_className = ValueConversions<String>::fromValue(classNameValue, errors);
+    }
+    protocol::Value* valueValue = object->get("value");
+    if (valueValue) {
+        errors->setName("value");
+        result->m_value = ValueConversions<protocol::Value>::fromValue(valueValue, errors);
+    }
+    protocol::Value* unserializableValueValue = object->get("unserializableValue");
+    if (unserializableValueValue) {
+        errors->setName("unserializableValue");
+        result->m_unserializableValue = ValueConversions<String>::fromValue(unserializableValueValue, errors);
+    }
+    protocol::Value* descriptionValue = object->get("description");
+    if (descriptionValue) {
+        errors->setName("description");
+        result->m_description = ValueConversions<String>::fromValue(descriptionValue, errors);
+    }
+    protocol::Value* objectIdValue = object->get("objectId");
+    if (objectIdValue) {
+        errors->setName("objectId");
+        result->m_objectId = ValueConversions<String>::fromValue(objectIdValue, errors);
+    }
+    protocol::Value* previewValue = object->get("preview");
+    if (previewValue) {
+        errors->setName("preview");
+        result->m_preview = ValueConversions<protocol::Runtime::ObjectPreview>::fromValue(previewValue, errors);
+    }
+    protocol::Value* customPreviewValue = object->get("customPreview");
+    if (customPreviewValue) {
+        errors->setName("customPreview");
+        result->m_customPreview = ValueConversions<protocol::Runtime::CustomPreview>::fromValue(customPreviewValue, errors);
+    }
+    errors->pop();
+    if (errors->hasErrors())
+        return nullptr;
+    return result;
+}
+
+std::unique_ptr<protocol::DictionaryValue> RemoteObject::toValue() const
+{
+    std::unique_ptr<protocol::DictionaryValue> result = DictionaryValue::create();
+    result->setValue("type", ValueConversions<String>::toValue(m_type));
+    if (m_subtype.isJust())
+        result->setValue("subtype", ValueConversions<String>::toValue(m_subtype.fromJust()));
+    if (m_className.isJust())
+        result->setValue("className", ValueConversions<String>::toValue(m_className.fromJust()));
+    if (m_value.isJust())
+        result->setValue("value", ValueConversions<protocol::Value>::toValue(m_value.fromJust()));
+    if (m_unserializableValue.isJust())
+        result->setValue("unserializableValue", ValueConversions<String>::toValue(m_unserializableValue.fromJust()));
+    if (m_description.isJust())
+        result->setValue("description", ValueConversions<String>::toValue(m_description.fromJust()));
+    if (m_objectId.isJust())
+        result->setValue("objectId", ValueConversions<String>::toValue(m_objectId.fromJust()));
+    if (m_preview.isJust())
+        result->setValue("preview", ValueConversions<protocol::Runtime::ObjectPreview>::toValue(m_preview.fromJust()));
+    if (m_customPreview.isJust())
+        result->setValue("customPreview", ValueConversions<protocol::Runtime::CustomPreview>::toValue(m_customPreview.fromJust()));
+    return result;
+}
+
+std::unique_ptr<RemoteObject> RemoteObject::clone() const
+{
+    ErrorSupport errors;
+    return fromValue(toValue().get(), &errors);
+}
+
+std::unique_ptr<StringBuffer> RemoteObject::toJSONString() const
+{
+    String json = toValue()->serialize();
+    return StringBufferImpl::adopt(json);
+}
+
+// static
+std::unique_ptr<API::RemoteObject> API::RemoteObject::fromJSONString(const StringView& json)
+{
+    ErrorSupport errors;
+    std::unique_ptr<Value> value = StringUtil::parseJSON(json);
+    if (!value)
+        return nullptr;
+    return protocol::Runtime::RemoteObject::fromValue(value.get(), &errors);
+}
+
+std::unique_ptr<CustomPreview> CustomPreview::fromValue(protocol::Value* value, ErrorSupport* errors)
+{
+    if (!value || value->type() != protocol::Value::TypeObject) {
+        errors->addError("object expected");
+        return nullptr;
+    }
+
+    std::unique_ptr<CustomPreview> result(new CustomPreview());
+    protocol::DictionaryValue* object = DictionaryValue::cast(value);
+    errors->push();
+    protocol::Value* headerValue = object->get("header");
+    errors->setName("header");
+    result->m_header = ValueConversions<String>::fromValue(headerValue, errors);
+    protocol::Value* hasBodyValue = object->get("hasBody");
+    errors->setName("hasBody");
+    result->m_hasBody = ValueConversions<bool>::fromValue(hasBodyValue, errors);
+    protocol::Value* formatterObjectIdValue = object->get("formatterObjectId");
+    errors->setName("formatterObjectId");
+    result->m_formatterObjectId = ValueConversions<String>::fromValue(formatterObjectIdValue, errors);
+    protocol::Value* bindRemoteObjectFunctionIdValue = object->get("bindRemoteObjectFunctionId");
+    errors->setName("bindRemoteObjectFunctionId");
+    result->m_bindRemoteObjectFunctionId = ValueConversions<String>::fromValue(bindRemoteObjectFunctionIdValue, errors);
+    protocol::Value* configObjectIdValue = object->get("configObjectId");
+    if (configObjectIdValue) {
+        errors->setName("configObjectId");
+        result->m_configObjectId = ValueConversions<String>::fromValue(configObjectIdValue, errors);
+    }
+    errors->pop();
+    if (errors->hasErrors())
+        return nullptr;
+    return result;
+}
+
+std::unique_ptr<protocol::DictionaryValue> CustomPreview::toValue() const
+{
+    std::unique_ptr<protocol::DictionaryValue> result = DictionaryValue::create();
+    result->setValue("header", ValueConversions<String>::toValue(m_header));
+    result->setValue("hasBody", ValueConversions<bool>::toValue(m_hasBody));
+    result->setValue("formatterObjectId", ValueConversions<String>::toValue(m_formatterObjectId));
+    result->setValue("bindRemoteObjectFunctionId", ValueConversions<String>::toValue(m_bindRemoteObjectFunctionId));
+    if (m_configObjectId.isJust())
+        result->setValue("configObjectId", ValueConversions<String>::toValue(m_configObjectId.fromJust()));
+    return result;
+}
+
+std::unique_ptr<CustomPreview> CustomPreview::clone() const
+{
+    ErrorSupport errors;
+    return fromValue(toValue().get(), &errors);
+}
+
+const char* ObjectPreview::TypeEnum::Object = "object";
+const char* ObjectPreview::TypeEnum::Function = "function";
+const char* ObjectPreview::TypeEnum::Undefined = "undefined";
+const char* ObjectPreview::TypeEnum::String = "string";
+const char* ObjectPreview::TypeEnum::Number = "number";
+const char* ObjectPreview::TypeEnum::Boolean = "boolean";
+const char* ObjectPreview::TypeEnum::Symbol = "symbol";
+
+const char* ObjectPreview::SubtypeEnum::Array = "array";
+const char* ObjectPreview::SubtypeEnum::Null = "null";
+const char* ObjectPreview::SubtypeEnum::Node = "node";
+const char* ObjectPreview::SubtypeEnum::Regexp = "regexp";
+const char* ObjectPreview::SubtypeEnum::Date = "date";
+const char* ObjectPreview::SubtypeEnum::Map = "map";
+const char* ObjectPreview::SubtypeEnum::Set = "set";
+const char* ObjectPreview::SubtypeEnum::Iterator = "iterator";
+const char* ObjectPreview::SubtypeEnum::Generator = "generator";
+const char* ObjectPreview::SubtypeEnum::Error = "error";
+
+std::unique_ptr<ObjectPreview> ObjectPreview::fromValue(protocol::Value* value, ErrorSupport* errors)
+{
+    if (!value || value->type() != protocol::Value::TypeObject) {
+        errors->addError("object expected");
+        return nullptr;
+    }
+
+    std::unique_ptr<ObjectPreview> result(new ObjectPreview());
+    protocol::DictionaryValue* object = DictionaryValue::cast(value);
+    errors->push();
+    protocol::Value* typeValue = object->get("type");
+    errors->setName("type");
+    result->m_type = ValueConversions<String>::fromValue(typeValue, errors);
+    protocol::Value* subtypeValue = object->get("subtype");
+    if (subtypeValue) {
+        errors->setName("subtype");
+        result->m_subtype = ValueConversions<String>::fromValue(subtypeValue, errors);
+    }
+    protocol::Value* descriptionValue = object->get("description");
+    if (descriptionValue) {
+        errors->setName("description");
+        result->m_description = ValueConversions<String>::fromValue(descriptionValue, errors);
+    }
+    protocol::Value* overflowValue = object->get("overflow");
+    errors->setName("overflow");
+    result->m_overflow = ValueConversions<bool>::fromValue(overflowValue, errors);
+    protocol::Value* propertiesValue = object->get("properties");
+    errors->setName("properties");
+    result->m_properties = ValueConversions<protocol::Array<protocol::Runtime::PropertyPreview>>::fromValue(propertiesValue, errors);
+    protocol::Value* entriesValue = object->get("entries");
+    if (entriesValue) {
+        errors->setName("entries");
+        result->m_entries = ValueConversions<protocol::Array<protocol::Runtime::EntryPreview>>::fromValue(entriesValue, errors);
+    }
+    errors->pop();
+    if (errors->hasErrors())
+        return nullptr;
+    return result;
+}
+
+std::unique_ptr<protocol::DictionaryValue> ObjectPreview::toValue() const
+{
+    std::unique_ptr<protocol::DictionaryValue> result = DictionaryValue::create();
+    result->setValue("type", ValueConversions<String>::toValue(m_type));
+    if (m_subtype.isJust())
+        result->setValue("subtype", ValueConversions<String>::toValue(m_subtype.fromJust()));
+    if (m_description.isJust())
+        result->setValue("description", ValueConversions<String>::toValue(m_description.fromJust()));
+    result->setValue("overflow", ValueConversions<bool>::toValue(m_overflow));
+    result->setValue("properties", ValueConversions<protocol::Array<protocol::Runtime::PropertyPreview>>::toValue(m_properties.get()));
+    if (m_entries.isJust())
+        result->setValue("entries", ValueConversions<protocol::Array<protocol::Runtime::EntryPreview>>::toValue(m_entries.fromJust()));
+    return result;
+}
+
+std::unique_ptr<ObjectPreview> ObjectPreview::clone() const
+{
+    ErrorSupport errors;
+    return fromValue(toValue().get(), &errors);
+}
+
+const char* PropertyPreview::TypeEnum::Object = "object";
+const char* PropertyPreview::TypeEnum::Function = "function";
+const char* PropertyPreview::TypeEnum::Undefined = "undefined";
+const char* PropertyPreview::TypeEnum::String = "string";
+const char* PropertyPreview::TypeEnum::Number = "number";
+const char* PropertyPreview::TypeEnum::Boolean = "boolean";
+const char* PropertyPreview::TypeEnum::Symbol = "symbol";
+const char* PropertyPreview::TypeEnum::Accessor = "accessor";
+
+const char* PropertyPreview::SubtypeEnum::Array = "array";
+const char* PropertyPreview::SubtypeEnum::Null = "null";
+const char* PropertyPreview::SubtypeEnum::Node = "node";
+const char* PropertyPreview::SubtypeEnum::Regexp = "regexp";
+const char* PropertyPreview::SubtypeEnum::Date = "date";
+const char* PropertyPreview::SubtypeEnum::Map = "map";
+const char* PropertyPreview::SubtypeEnum::Set = "set";
+const char* PropertyPreview::SubtypeEnum::Iterator = "iterator";
+const char* PropertyPreview::SubtypeEnum::Generator = "generator";
+const char* PropertyPreview::SubtypeEnum::Error = "error";
+
+std::unique_ptr<PropertyPreview> PropertyPreview::fromValue(protocol::Value* value, ErrorSupport* errors)
+{
+    if (!value || value->type() != protocol::Value::TypeObject) {
+        errors->addError("object expected");
+        return nullptr;
+    }
+
+    std::unique_ptr<PropertyPreview> result(new PropertyPreview());
+    protocol::DictionaryValue* object = DictionaryValue::cast(value);
+    errors->push();
+    protocol::Value* nameValue = object->get("name");
+    errors->setName("name");
+    result->m_name = ValueConversions<String>::fromValue(nameValue, errors);
+    protocol::Value* typeValue = object->get("type");
+    errors->setName("type");
+    result->m_type = ValueConversions<String>::fromValue(typeValue, errors);
+    protocol::Value* valueValue = object->get("value");
+    if (valueValue) {
+        errors->setName("value");
+        result->m_value = ValueConversions<String>::fromValue(valueValue, errors);
+    }
+    protocol::Value* valuePreviewValue = object->get("valuePreview");
+    if (valuePreviewValue) {
+        errors->setName("valuePreview");
+        result->m_valuePreview = ValueConversions<protocol::Runtime::ObjectPreview>::fromValue(valuePreviewValue, errors);
+    }
+    protocol::Value* subtypeValue = object->get("subtype");
+    if (subtypeValue) {
+        errors->setName("subtype");
+        result->m_subtype = ValueConversions<String>::fromValue(subtypeValue, errors);
+    }
+    errors->pop();
+    if (errors->hasErrors())
+        return nullptr;
+    return result;
+}
+
+std::unique_ptr<protocol::DictionaryValue> PropertyPreview::toValue() const
+{
+    std::unique_ptr<protocol::DictionaryValue> result = DictionaryValue::create();
+    result->setValue("name", ValueConversions<String>::toValue(m_name));
+    result->setValue("type", ValueConversions<String>::toValue(m_type));
+    if (m_value.isJust())
+        result->setValue("value", ValueConversions<String>::toValue(m_value.fromJust()));
+    if (m_valuePreview.isJust())
+        result->setValue("valuePreview", ValueConversions<protocol::Runtime::ObjectPreview>::toValue(m_valuePreview.fromJust()));
+    if (m_subtype.isJust())
+        result->setValue("subtype", ValueConversions<String>::toValue(m_subtype.fromJust()));
+    return result;
+}
+
+std::unique_ptr<PropertyPreview> PropertyPreview::clone() const
+{
+    ErrorSupport errors;
+    return fromValue(toValue().get(), &errors);
+}
+
+std::unique_ptr<EntryPreview> EntryPreview::fromValue(protocol::Value* value, ErrorSupport* errors)
+{
+    if (!value || value->type() != protocol::Value::TypeObject) {
+        errors->addError("object expected");
+        return nullptr;
+    }
+
+    std::unique_ptr<EntryPreview> result(new EntryPreview());
+    protocol::DictionaryValue* object = DictionaryValue::cast(value);
+    errors->push();
+    protocol::Value* keyValue = object->get("key");
+    if (keyValue) {
+        errors->setName("key");
+        result->m_key = ValueConversions<protocol::Runtime::ObjectPreview>::fromValue(keyValue, errors);
+    }
+    protocol::Value* valueValue = object->get("value");
+    errors->setName("value");
+    result->m_value = ValueConversions<protocol::Runtime::ObjectPreview>::fromValue(valueValue, errors);
+    errors->pop();
+    if (errors->hasErrors())
+        return nullptr;
+    return result;
+}
+
+std::unique_ptr<protocol::DictionaryValue> EntryPreview::toValue() const
+{
+    std::unique_ptr<protocol::DictionaryValue> result = DictionaryValue::create();
+    if (m_key.isJust())
+        result->setValue("key", ValueConversions<protocol::Runtime::ObjectPreview>::toValue(m_key.fromJust()));
+    result->setValue("value", ValueConversions<protocol::Runtime::ObjectPreview>::toValue(m_value.get()));
+    return result;
+}
+
+std::unique_ptr<EntryPreview> EntryPreview::clone() const
+{
+    ErrorSupport errors;
+    return fromValue(toValue().get(), &errors);
+}
+
+std::unique_ptr<PropertyDescriptor> PropertyDescriptor::fromValue(protocol::Value* value, ErrorSupport* errors)
+{
+    if (!value || value->type() != protocol::Value::TypeObject) {
+        errors->addError("object expected");
+        return nullptr;
+    }
+
+    std::unique_ptr<PropertyDescriptor> result(new PropertyDescriptor());
+    protocol::DictionaryValue* object = DictionaryValue::cast(value);
+    errors->push();
+    protocol::Value* nameValue = object->get("name");
+    errors->setName("name");
+    result->m_name = ValueConversions<String>::fromValue(nameValue, errors);
+    protocol::Value* valueValue = object->get("value");
+    if (valueValue) {
+        errors->setName("value");
+        result->m_value = ValueConversions<protocol::Runtime::RemoteObject>::fromValue(valueValue, errors);
+    }
+    protocol::Value* writableValue = object->get("writable");
+    if (writableValue) {
+        errors->setName("writable");
+        result->m_writable = ValueConversions<bool>::fromValue(writableValue, errors);
+    }
+    protocol::Value* getValue = object->get("get");
+    if (getValue) {
+        errors->setName("get");
+        result->m_get = ValueConversions<protocol::Runtime::RemoteObject>::fromValue(getValue, errors);
+    }
+    protocol::Value* setValue = object->get("set");
+    if (setValue) {
+        errors->setName("set");
+        result->m_set = ValueConversions<protocol::Runtime::RemoteObject>::fromValue(setValue, errors);
+    }
+    protocol::Value* configurableValue = object->get("configurable");
+    errors->setName("configurable");
+    result->m_configurable = ValueConversions<bool>::fromValue(configurableValue, errors);
+    protocol::Value* enumerableValue = object->get("enumerable");
+    errors->setName("enumerable");
+    result->m_enumerable = ValueConversions<bool>::fromValue(enumerableValue, errors);
+    protocol::Value* wasThrownValue = object->get("wasThrown");
+    if (wasThrownValue) {
+        errors->setName("wasThrown");
+        result->m_wasThrown = ValueConversions<bool>::fromValue(wasThrownValue, errors);
+    }
+    protocol::Value* isOwnValue = object->get("isOwn");
+    if (isOwnValue) {
+        errors->setName("isOwn");
+        result->m_isOwn = ValueConversions<bool>::fromValue(isOwnValue, errors);
+    }
+    protocol::Value* symbolValue = object->get("symbol");
+    if (symbolValue) {
+        errors->setName("symbol");
+        result->m_symbol = ValueConversions<protocol::Runtime::RemoteObject>::fromValue(symbolValue, errors);
+    }
+    errors->pop();
+    if (errors->hasErrors())
+        return nullptr;
+    return result;
+}
+
+std::unique_ptr<protocol::DictionaryValue> PropertyDescriptor::toValue() const
+{
+    std::unique_ptr<protocol::DictionaryValue> result = DictionaryValue::create();
+    result->setValue("name", ValueConversions<String>::toValue(m_name));
+    if (m_value.isJust())
+        result->setValue("value", ValueConversions<protocol::Runtime::RemoteObject>::toValue(m_value.fromJust()));
+    if (m_writable.isJust())
+        result->setValue("writable", ValueConversions<bool>::toValue(m_writable.fromJust()));
+    if (m_get.isJust())
+        result->setValue("get", ValueConversions<protocol::Runtime::RemoteObject>::toValue(m_get.fromJust()));
+    if (m_set.isJust())
+        result->setValue("set", ValueConversions<protocol::Runtime::RemoteObject>::toValue(m_set.fromJust()));
+    result->setValue("configurable", ValueConversions<bool>::toValue(m_configurable));
+    result->setValue("enumerable", ValueConversions<bool>::toValue(m_enumerable));
+    if (m_wasThrown.isJust())
+        result->setValue("wasThrown", ValueConversions<bool>::toValue(m_wasThrown.fromJust()));
+    if (m_isOwn.isJust())
+        result->setValue("isOwn", ValueConversions<bool>::toValue(m_isOwn.fromJust()));
+    if (m_symbol.isJust())
+        result->setValue("symbol", ValueConversions<protocol::Runtime::RemoteObject>::toValue(m_symbol.fromJust()));
+    return result;
+}
+
+std::unique_ptr<PropertyDescriptor> PropertyDescriptor::clone() const
+{
+    ErrorSupport errors;
+    return fromValue(toValue().get(), &errors);
+}
+
+std::unique_ptr<InternalPropertyDescriptor> InternalPropertyDescriptor::fromValue(protocol::Value* value, ErrorSupport* errors)
+{
+    if (!value || value->type() != protocol::Value::TypeObject) {
+        errors->addError("object expected");
+        return nullptr;
+    }
+
+    std::unique_ptr<InternalPropertyDescriptor> result(new InternalPropertyDescriptor());
+    protocol::DictionaryValue* object = DictionaryValue::cast(value);
+    errors->push();
+    protocol::Value* nameValue = object->get("name");
+    errors->setName("name");
+    result->m_name = ValueConversions<String>::fromValue(nameValue, errors);
+    protocol::Value* valueValue = object->get("value");
+    if (valueValue) {
+        errors->setName("value");
+        result->m_value = ValueConversions<protocol::Runtime::RemoteObject>::fromValue(valueValue, errors);
+    }
+    errors->pop();
+    if (errors->hasErrors())
+        return nullptr;
+    return result;
+}
+
+std::unique_ptr<protocol::DictionaryValue> InternalPropertyDescriptor::toValue() const
+{
+    std::unique_ptr<protocol::DictionaryValue> result = DictionaryValue::create();
+    result->setValue("name", ValueConversions<String>::toValue(m_name));
+    if (m_value.isJust())
+        result->setValue("value", ValueConversions<protocol::Runtime::RemoteObject>::toValue(m_value.fromJust()));
+    return result;
+}
+
+std::unique_ptr<InternalPropertyDescriptor> InternalPropertyDescriptor::clone() const
+{
+    ErrorSupport errors;
+    return fromValue(toValue().get(), &errors);
+}
+
+std::unique_ptr<CallArgument> CallArgument::fromValue(protocol::Value* value, ErrorSupport* errors)
+{
+    if (!value || value->type() != protocol::Value::TypeObject) {
+        errors->addError("object expected");
+        return nullptr;
+    }
+
+    std::unique_ptr<CallArgument> result(new CallArgument());
+    protocol::DictionaryValue* object = DictionaryValue::cast(value);
+    errors->push();
+    protocol::Value* valueValue = object->get("value");
+    if (valueValue) {
+        errors->setName("value");
+        result->m_value = ValueConversions<protocol::Value>::fromValue(valueValue, errors);
+    }
+    protocol::Value* unserializableValueValue = object->get("unserializableValue");
+    if (unserializableValueValue) {
+        errors->setName("unserializableValue");
+        result->m_unserializableValue = ValueConversions<String>::fromValue(unserializableValueValue, errors);
+    }
+    protocol::Value* objectIdValue = object->get("objectId");
+    if (objectIdValue) {
+        errors->setName("objectId");
+        result->m_objectId = ValueConversions<String>::fromValue(objectIdValue, errors);
+    }
+    errors->pop();
+    if (errors->hasErrors())
+        return nullptr;
+    return result;
+}
+
+std::unique_ptr<protocol::DictionaryValue> CallArgument::toValue() const
+{
+    std::unique_ptr<protocol::DictionaryValue> result = DictionaryValue::create();
+    if (m_value.isJust())
+        result->setValue("value", ValueConversions<protocol::Value>::toValue(m_value.fromJust()));
+    if (m_unserializableValue.isJust())
+        result->setValue("unserializableValue", ValueConversions<String>::toValue(m_unserializableValue.fromJust()));
+    if (m_objectId.isJust())
+        result->setValue("objectId", ValueConversions<String>::toValue(m_objectId.fromJust()));
+    return result;
+}
+
+std::unique_ptr<CallArgument> CallArgument::clone() const
+{
+    ErrorSupport errors;
+    return fromValue(toValue().get(), &errors);
+}
+
+std::unique_ptr<ExecutionContextDescription> ExecutionContextDescription::fromValue(protocol::Value* value, ErrorSupport* errors)
+{
+    if (!value || value->type() != protocol::Value::TypeObject) {
+        errors->addError("object expected");
+        return nullptr;
+    }
+
+    std::unique_ptr<ExecutionContextDescription> result(new ExecutionContextDescription());
+    protocol::DictionaryValue* object = DictionaryValue::cast(value);
+    errors->push();
+    protocol::Value* idValue = object->get("id");
+    errors->setName("id");
+    result->m_id = ValueConversions<int>::fromValue(idValue, errors);
+    protocol::Value* originValue = object->get("origin");
+    errors->setName("origin");
+    result->m_origin = ValueConversions<String>::fromValue(originValue, errors);
+    protocol::Value* nameValue = object->get("name");
+    errors->setName("name");
+    result->m_name = ValueConversions<String>::fromValue(nameValue, errors);
+    protocol::Value* auxDataValue = object->get("auxData");
+    if (auxDataValue) {
+        errors->setName("auxData");
+        result->m_auxData = ValueConversions<protocol::DictionaryValue>::fromValue(auxDataValue, errors);
+    }
+    errors->pop();
+    if (errors->hasErrors())
+        return nullptr;
+    return result;
+}
+
+std::unique_ptr<protocol::DictionaryValue> ExecutionContextDescription::toValue() const
+{
+    std::unique_ptr<protocol::DictionaryValue> result = DictionaryValue::create();
+    result->setValue("id", ValueConversions<int>::toValue(m_id));
+    result->setValue("origin", ValueConversions<String>::toValue(m_origin));
+    result->setValue("name", ValueConversions<String>::toValue(m_name));
+    if (m_auxData.isJust())
+        result->setValue("auxData", ValueConversions<protocol::DictionaryValue>::toValue(m_auxData.fromJust()));
+    return result;
+}
+
+std::unique_ptr<ExecutionContextDescription> ExecutionContextDescription::clone() const
+{
+    ErrorSupport errors;
+    return fromValue(toValue().get(), &errors);
+}
+
+std::unique_ptr<ExceptionDetails> ExceptionDetails::fromValue(protocol::Value* value, ErrorSupport* errors)
+{
+    if (!value || value->type() != protocol::Value::TypeObject) {
+        errors->addError("object expected");
+        return nullptr;
+    }
+
+    std::unique_ptr<ExceptionDetails> result(new ExceptionDetails());
+    protocol::DictionaryValue* object = DictionaryValue::cast(value);
+    errors->push();
+    protocol::Value* exceptionIdValue = object->get("exceptionId");
+    errors->setName("exceptionId");
+    result->m_exceptionId = ValueConversions<int>::fromValue(exceptionIdValue, errors);
+    protocol::Value* textValue = object->get("text");
+    errors->setName("text");
+    result->m_text = ValueConversions<String>::fromValue(textValue, errors);
+    protocol::Value* lineNumberValue = object->get("lineNumber");
+    errors->setName("lineNumber");
+    result->m_lineNumber = ValueConversions<int>::fromValue(lineNumberValue, errors);
+    protocol::Value* columnNumberValue = object->get("columnNumber");
+    errors->setName("columnNumber");
+    result->m_columnNumber = ValueConversions<int>::fromValue(columnNumberValue, errors);
+    protocol::Value* scriptIdValue = object->get("scriptId");
+    if (scriptIdValue) {
+        errors->setName("scriptId");
+        result->m_scriptId = ValueConversions<String>::fromValue(scriptIdValue, errors);
+    }
+    protocol::Value* urlValue = object->get("url");
+    if (urlValue) {
+        errors->setName("url");
+        result->m_url = ValueConversions<String>::fromValue(urlValue, errors);
+    }
+    protocol::Value* stackTraceValue = object->get("stackTrace");
+    if (stackTraceValue) {
+        errors->setName("stackTrace");
+        result->m_stackTrace = ValueConversions<protocol::Runtime::StackTrace>::fromValue(stackTraceValue, errors);
+    }
+    protocol::Value* exceptionValue = object->get("exception");
+    if (exceptionValue) {
+        errors->setName("exception");
+        result->m_exception = ValueConversions<protocol::Runtime::RemoteObject>::fromValue(exceptionValue, errors);
+    }
+    protocol::Value* executionContextIdValue = object->get("executionContextId");
+    if (executionContextIdValue) {
+        errors->setName("executionContextId");
+        result->m_executionContextId = ValueConversions<int>::fromValue(executionContextIdValue, errors);
+    }
+    errors->pop();
+    if (errors->hasErrors())
+        return nullptr;
+    return result;
+}
+
+std::unique_ptr<protocol::DictionaryValue> ExceptionDetails::toValue() const
+{
+    std::unique_ptr<protocol::DictionaryValue> result = DictionaryValue::create();
+    result->setValue("exceptionId", ValueConversions<int>::toValue(m_exceptionId));
+    result->setValue("text", ValueConversions<String>::toValue(m_text));
+    result->setValue("lineNumber", ValueConversions<int>::toValue(m_lineNumber));
+    result->setValue("columnNumber", ValueConversions<int>::toValue(m_columnNumber));
+    if (m_scriptId.isJust())
+        result->setValue("scriptId", ValueConversions<String>::toValue(m_scriptId.fromJust()));
+    if (m_url.isJust())
+        result->setValue("url", ValueConversions<String>::toValue(m_url.fromJust()));
+    if (m_stackTrace.isJust())
+        result->setValue("stackTrace", ValueConversions<protocol::Runtime::StackTrace>::toValue(m_stackTrace.fromJust()));
+    if (m_exception.isJust())
+        result->setValue("exception", ValueConversions<protocol::Runtime::RemoteObject>::toValue(m_exception.fromJust()));
+    if (m_executionContextId.isJust())
+        result->setValue("executionContextId", ValueConversions<int>::toValue(m_executionContextId.fromJust()));
+    return result;
+}
+
+std::unique_ptr<ExceptionDetails> ExceptionDetails::clone() const
+{
+    ErrorSupport errors;
+    return fromValue(toValue().get(), &errors);
+}
+
+std::unique_ptr<CallFrame> CallFrame::fromValue(protocol::Value* value, ErrorSupport* errors)
+{
+    if (!value || value->type() != protocol::Value::TypeObject) {
+        errors->addError("object expected");
+        return nullptr;
+    }
+
+    std::unique_ptr<CallFrame> result(new CallFrame());
+    protocol::DictionaryValue* object = DictionaryValue::cast(value);
+    errors->push();
+    protocol::Value* functionNameValue = object->get("functionName");
+    errors->setName("functionName");
+    result->m_functionName = ValueConversions<String>::fromValue(functionNameValue, errors);
+    protocol::Value* scriptIdValue = object->get("scriptId");
+    errors->setName("scriptId");
+    result->m_scriptId = ValueConversions<String>::fromValue(scriptIdValue, errors);
+    protocol::Value* urlValue = object->get("url");
+    errors->setName("url");
+    result->m_url = ValueConversions<String>::fromValue(urlValue, errors);
+    protocol::Value* lineNumberValue = object->get("lineNumber");
+    errors->setName("lineNumber");
+    result->m_lineNumber = ValueConversions<int>::fromValue(lineNumberValue, errors);
+    protocol::Value* columnNumberValue = object->get("columnNumber");
+    errors->setName("columnNumber");
+    result->m_columnNumber = ValueConversions<int>::fromValue(columnNumberValue, errors);
+    errors->pop();
+    if (errors->hasErrors())
+        return nullptr;
+    return result;
+}
+
+std::unique_ptr<protocol::DictionaryValue> CallFrame::toValue() const
+{
+    std::unique_ptr<protocol::DictionaryValue> result = DictionaryValue::create();
+    result->setValue("functionName", ValueConversions<String>::toValue(m_functionName));
+    result->setValue("scriptId", ValueConversions<String>::toValue(m_scriptId));
+    result->setValue("url", ValueConversions<String>::toValue(m_url));
+    result->setValue("lineNumber", ValueConversions<int>::toValue(m_lineNumber));
+    result->setValue("columnNumber", ValueConversions<int>::toValue(m_columnNumber));
+    return result;
+}
+
+std::unique_ptr<CallFrame> CallFrame::clone() const
+{
+    ErrorSupport errors;
+    return fromValue(toValue().get(), &errors);
+}
+
+std::unique_ptr<StackTrace> StackTrace::fromValue(protocol::Value* value, ErrorSupport* errors)
+{
+    if (!value || value->type() != protocol::Value::TypeObject) {
+        errors->addError("object expected");
+        return nullptr;
+    }
+
+    std::unique_ptr<StackTrace> result(new StackTrace());
+    protocol::DictionaryValue* object = DictionaryValue::cast(value);
+    errors->push();
+    protocol::Value* descriptionValue = object->get("description");
+    if (descriptionValue) {
+        errors->setName("description");
+        result->m_description = ValueConversions<String>::fromValue(descriptionValue, errors);
+    }
+    protocol::Value* callFramesValue = object->get("callFrames");
+    errors->setName("callFrames");
+    result->m_callFrames = ValueConversions<protocol::Array<protocol::Runtime::CallFrame>>::fromValue(callFramesValue, errors);
+    protocol::Value* parentValue = object->get("parent");
+    if (parentValue) {
+        errors->setName("parent");
+        result->m_parent = ValueConversions<protocol::Runtime::StackTrace>::fromValue(parentValue, errors);
+    }
+    errors->pop();
+    if (errors->hasErrors())
+        return nullptr;
+    return result;
+}
+
+std::unique_ptr<protocol::DictionaryValue> StackTrace::toValue() const
+{
+    std::unique_ptr<protocol::DictionaryValue> result = DictionaryValue::create();
+    if (m_description.isJust())
+        result->setValue("description", ValueConversions<String>::toValue(m_description.fromJust()));
+    result->setValue("callFrames", ValueConversions<protocol::Array<protocol::Runtime::CallFrame>>::toValue(m_callFrames.get()));
+    if (m_parent.isJust())
+        result->setValue("parent", ValueConversions<protocol::Runtime::StackTrace>::toValue(m_parent.fromJust()));
+    return result;
+}
+
+std::unique_ptr<StackTrace> StackTrace::clone() const
+{
+    ErrorSupport errors;
+    return fromValue(toValue().get(), &errors);
+}
+
+std::unique_ptr<StringBuffer> StackTrace::toJSONString() const
+{
+    String json = toValue()->serialize();
+    return StringBufferImpl::adopt(json);
+}
+
+// static
+std::unique_ptr<API::StackTrace> API::StackTrace::fromJSONString(const StringView& json)
+{
+    ErrorSupport errors;
+    std::unique_ptr<Value> value = StringUtil::parseJSON(json);
+    if (!value)
+        return nullptr;
+    return protocol::Runtime::StackTrace::fromValue(value.get(), &errors);
+}
+
+std::unique_ptr<ExecutionContextCreatedNotification> ExecutionContextCreatedNotification::fromValue(protocol::Value* value, ErrorSupport* errors)
+{
+    if (!value || value->type() != protocol::Value::TypeObject) {
+        errors->addError("object expected");
+        return nullptr;
+    }
+
+    std::unique_ptr<ExecutionContextCreatedNotification> result(new ExecutionContextCreatedNotification());
+    protocol::DictionaryValue* object = DictionaryValue::cast(value);
+    errors->push();
+    protocol::Value* contextValue = object->get("context");
+    errors->setName("context");
+    result->m_context = ValueConversions<protocol::Runtime::ExecutionContextDescription>::fromValue(contextValue, errors);
+    errors->pop();
+    if (errors->hasErrors())
+        return nullptr;
+    return result;
+}
+
+std::unique_ptr<protocol::DictionaryValue> ExecutionContextCreatedNotification::toValue() const
+{
+    std::unique_ptr<protocol::DictionaryValue> result = DictionaryValue::create();
+    result->setValue("context", ValueConversions<protocol::Runtime::ExecutionContextDescription>::toValue(m_context.get()));
+    return result;
+}
+
+std::unique_ptr<ExecutionContextCreatedNotification> ExecutionContextCreatedNotification::clone() const
+{
+    ErrorSupport errors;
+    return fromValue(toValue().get(), &errors);
+}
+
+std::unique_ptr<ExecutionContextDestroyedNotification> ExecutionContextDestroyedNotification::fromValue(protocol::Value* value, ErrorSupport* errors)
+{
+    if (!value || value->type() != protocol::Value::TypeObject) {
+        errors->addError("object expected");
+        return nullptr;
+    }
+
+    std::unique_ptr<ExecutionContextDestroyedNotification> result(new ExecutionContextDestroyedNotification());
+    protocol::DictionaryValue* object = DictionaryValue::cast(value);
+    errors->push();
+    protocol::Value* executionContextIdValue = object->get("executionContextId");
+    errors->setName("executionContextId");
+    result->m_executionContextId = ValueConversions<int>::fromValue(executionContextIdValue, errors);
+    errors->pop();
+    if (errors->hasErrors())
+        return nullptr;
+    return result;
+}
+
+std::unique_ptr<protocol::DictionaryValue> ExecutionContextDestroyedNotification::toValue() const
+{
+    std::unique_ptr<protocol::DictionaryValue> result = DictionaryValue::create();
+    result->setValue("executionContextId", ValueConversions<int>::toValue(m_executionContextId));
+    return result;
+}
+
+std::unique_ptr<ExecutionContextDestroyedNotification> ExecutionContextDestroyedNotification::clone() const
+{
+    ErrorSupport errors;
+    return fromValue(toValue().get(), &errors);
+}
+
+std::unique_ptr<ExceptionThrownNotification> ExceptionThrownNotification::fromValue(protocol::Value* value, ErrorSupport* errors)
+{
+    if (!value || value->type() != protocol::Value::TypeObject) {
+        errors->addError("object expected");
+        return nullptr;
+    }
+
+    std::unique_ptr<ExceptionThrownNotification> result(new ExceptionThrownNotification());
+    protocol::DictionaryValue* object = DictionaryValue::cast(value);
+    errors->push();
+    protocol::Value* timestampValue = object->get("timestamp");
+    errors->setName("timestamp");
+    result->m_timestamp = ValueConversions<double>::fromValue(timestampValue, errors);
+    protocol::Value* exceptionDetailsValue = object->get("exceptionDetails");
+    errors->setName("exceptionDetails");
+    result->m_exceptionDetails = ValueConversions<protocol::Runtime::ExceptionDetails>::fromValue(exceptionDetailsValue, errors);
+    errors->pop();
+    if (errors->hasErrors())
+        return nullptr;
+    return result;
+}
+
+std::unique_ptr<protocol::DictionaryValue> ExceptionThrownNotification::toValue() const
+{
+    std::unique_ptr<protocol::DictionaryValue> result = DictionaryValue::create();
+    result->setValue("timestamp", ValueConversions<double>::toValue(m_timestamp));
+    result->setValue("exceptionDetails", ValueConversions<protocol::Runtime::ExceptionDetails>::toValue(m_exceptionDetails.get()));
+    return result;
+}
+
+std::unique_ptr<ExceptionThrownNotification> ExceptionThrownNotification::clone() const
+{
+    ErrorSupport errors;
+    return fromValue(toValue().get(), &errors);
+}
+
+std::unique_ptr<ExceptionRevokedNotification> ExceptionRevokedNotification::fromValue(protocol::Value* value, ErrorSupport* errors)
+{
+    if (!value || value->type() != protocol::Value::TypeObject) {
+        errors->addError("object expected");
+        return nullptr;
+    }
+
+    std::unique_ptr<ExceptionRevokedNotification> result(new ExceptionRevokedNotification());
+    protocol::DictionaryValue* object = DictionaryValue::cast(value);
+    errors->push();
+    protocol::Value* reasonValue = object->get("reason");
+    errors->setName("reason");
+    result->m_reason = ValueConversions<String>::fromValue(reasonValue, errors);
+    protocol::Value* exceptionIdValue = object->get("exceptionId");
+    errors->setName("exceptionId");
+    result->m_exceptionId = ValueConversions<int>::fromValue(exceptionIdValue, errors);
+    errors->pop();
+    if (errors->hasErrors())
+        return nullptr;
+    return result;
+}
+
+std::unique_ptr<protocol::DictionaryValue> ExceptionRevokedNotification::toValue() const
+{
+    std::unique_ptr<protocol::DictionaryValue> result = DictionaryValue::create();
+    result->setValue("reason", ValueConversions<String>::toValue(m_reason));
+    result->setValue("exceptionId", ValueConversions<int>::toValue(m_exceptionId));
+    return result;
+}
+
+std::unique_ptr<ExceptionRevokedNotification> ExceptionRevokedNotification::clone() const
+{
+    ErrorSupport errors;
+    return fromValue(toValue().get(), &errors);
+}
+
+const char* ConsoleAPICalledNotification::TypeEnum::Log = "log";
+const char* ConsoleAPICalledNotification::TypeEnum::Debug = "debug";
+const char* ConsoleAPICalledNotification::TypeEnum::Info = "info";
+const char* ConsoleAPICalledNotification::TypeEnum::Error = "error";
+const char* ConsoleAPICalledNotification::TypeEnum::Warning = "warning";
+const char* ConsoleAPICalledNotification::TypeEnum::Dir = "dir";
+const char* ConsoleAPICalledNotification::TypeEnum::Dirxml = "dirxml";
+const char* ConsoleAPICalledNotification::TypeEnum::Table = "table";
+const char* ConsoleAPICalledNotification::TypeEnum::Trace = "trace";
+const char* ConsoleAPICalledNotification::TypeEnum::Clear = "clear";
+const char* ConsoleAPICalledNotification::TypeEnum::StartGroup = "startGroup";
+const char* ConsoleAPICalledNotification::TypeEnum::StartGroupCollapsed = "startGroupCollapsed";
+const char* ConsoleAPICalledNotification::TypeEnum::EndGroup = "endGroup";
+const char* ConsoleAPICalledNotification::TypeEnum::Assert = "assert";
+const char* ConsoleAPICalledNotification::TypeEnum::Profile = "profile";
+const char* ConsoleAPICalledNotification::TypeEnum::ProfileEnd = "profileEnd";
+
+std::unique_ptr<ConsoleAPICalledNotification> ConsoleAPICalledNotification::fromValue(protocol::Value* value, ErrorSupport* errors)
+{
+    if (!value || value->type() != protocol::Value::TypeObject) {
+        errors->addError("object expected");
+        return nullptr;
+    }
+
+    std::unique_ptr<ConsoleAPICalledNotification> result(new ConsoleAPICalledNotification());
+    protocol::DictionaryValue* object = DictionaryValue::cast(value);
+    errors->push();
+    protocol::Value* typeValue = object->get("type");
+    errors->setName("type");
+    result->m_type = ValueConversions<String>::fromValue(typeValue, errors);
+    protocol::Value* argsValue = object->get("args");
+    errors->setName("args");
+    result->m_args = ValueConversions<protocol::Array<protocol::Runtime::RemoteObject>>::fromValue(argsValue, errors);
+    protocol::Value* executionContextIdValue = object->get("executionContextId");
+    errors->setName("executionContextId");
+    result->m_executionContextId = ValueConversions<int>::fromValue(executionContextIdValue, errors);
+    protocol::Value* timestampValue = object->get("timestamp");
+    errors->setName("timestamp");
+    result->m_timestamp = ValueConversions<double>::fromValue(timestampValue, errors);
+    protocol::Value* stackTraceValue = object->get("stackTrace");
+    if (stackTraceValue) {
+        errors->setName("stackTrace");
+        result->m_stackTrace = ValueConversions<protocol::Runtime::StackTrace>::fromValue(stackTraceValue, errors);
+    }
+    errors->pop();
+    if (errors->hasErrors())
+        return nullptr;
+    return result;
+}
+
+std::unique_ptr<protocol::DictionaryValue> ConsoleAPICalledNotification::toValue() const
+{
+    std::unique_ptr<protocol::DictionaryValue> result = DictionaryValue::create();
+    result->setValue("type", ValueConversions<String>::toValue(m_type));
+    result->setValue("args", ValueConversions<protocol::Array<protocol::Runtime::RemoteObject>>::toValue(m_args.get()));
+    result->setValue("executionContextId", ValueConversions<int>::toValue(m_executionContextId));
+    result->setValue("timestamp", ValueConversions<double>::toValue(m_timestamp));
+    if (m_stackTrace.isJust())
+        result->setValue("stackTrace", ValueConversions<protocol::Runtime::StackTrace>::toValue(m_stackTrace.fromJust()));
+    return result;
+}
+
+std::unique_ptr<ConsoleAPICalledNotification> ConsoleAPICalledNotification::clone() const
+{
+    ErrorSupport errors;
+    return fromValue(toValue().get(), &errors);
+}
+
+std::unique_ptr<InspectRequestedNotification> InspectRequestedNotification::fromValue(protocol::Value* value, ErrorSupport* errors)
+{
+    if (!value || value->type() != protocol::Value::TypeObject) {
+        errors->addError("object expected");
+        return nullptr;
+    }
+
+    std::unique_ptr<InspectRequestedNotification> result(new InspectRequestedNotification());
+    protocol::DictionaryValue* object = DictionaryValue::cast(value);
+    errors->push();
+    protocol::Value* objectValue = object->get("object");
+    errors->setName("object");
+    result->m_object = ValueConversions<protocol::Runtime::RemoteObject>::fromValue(objectValue, errors);
+    protocol::Value* hintsValue = object->get("hints");
+    errors->setName("hints");
+    result->m_hints = ValueConversions<protocol::DictionaryValue>::fromValue(hintsValue, errors);
+    errors->pop();
+    if (errors->hasErrors())
+        return nullptr;
+    return result;
+}
+
+std::unique_ptr<protocol::DictionaryValue> InspectRequestedNotification::toValue() const
+{
+    std::unique_ptr<protocol::DictionaryValue> result = DictionaryValue::create();
+    result->setValue("object", ValueConversions<protocol::Runtime::RemoteObject>::toValue(m_object.get()));
+    result->setValue("hints", ValueConversions<protocol::DictionaryValue>::toValue(m_hints.get()));
+    return result;
+}
+
+std::unique_ptr<InspectRequestedNotification> InspectRequestedNotification::clone() const
+{
+    ErrorSupport errors;
+    return fromValue(toValue().get(), &errors);
+}
+
+// ------------- Enum values from params.
+
+
+namespace ConsoleAPICalled {
+namespace TypeEnum {
+const char* Log = "log";
+const char* Debug = "debug";
+const char* Info = "info";
+const char* Error = "error";
+const char* Warning = "warning";
+const char* Dir = "dir";
+const char* Dirxml = "dirxml";
+const char* Table = "table";
+const char* Trace = "trace";
+const char* Clear = "clear";
+const char* StartGroup = "startGroup";
+const char* StartGroupCollapsed = "startGroupCollapsed";
+const char* EndGroup = "endGroup";
+const char* Assert = "assert";
+const char* Profile = "profile";
+const char* ProfileEnd = "profileEnd";
+} // namespace TypeEnum
+} // namespace ConsoleAPICalled
+
+// ------------- Frontend notifications.
+
+void Frontend::executionContextCreated(std::unique_ptr<protocol::Runtime::ExecutionContextDescription> context)
+{
+    if (!m_frontendChannel)
+        return;
+    std::unique_ptr<ExecutionContextCreatedNotification> messageData = ExecutionContextCreatedNotification::create()
+        .setContext(std::move(context))
+        .build();
+    m_frontendChannel->sendProtocolNotification(InternalResponse::createNotification("Runtime.executionContextCreated", std::move(messageData)));
+}
+
+void Frontend::executionContextDestroyed(int executionContextId)
+{
+    if (!m_frontendChannel)
+        return;
+    std::unique_ptr<ExecutionContextDestroyedNotification> messageData = ExecutionContextDestroyedNotification::create()
+        .setExecutionContextId(executionContextId)
+        .build();
+    m_frontendChannel->sendProtocolNotification(InternalResponse::createNotification("Runtime.executionContextDestroyed", std::move(messageData)));
+}
+
+void Frontend::executionContextsCleared()
+{
+    if (!m_frontendChannel)
+        return;
+    m_frontendChannel->sendProtocolNotification(InternalResponse::createNotification("Runtime.executionContextsCleared"));
+}
+
+void Frontend::exceptionThrown(double timestamp, std::unique_ptr<protocol::Runtime::ExceptionDetails> exceptionDetails)
+{
+    if (!m_frontendChannel)
+        return;
+    std::unique_ptr<ExceptionThrownNotification> messageData = ExceptionThrownNotification::create()
+        .setTimestamp(timestamp)
+        .setExceptionDetails(std::move(exceptionDetails))
+        .build();
+    m_frontendChannel->sendProtocolNotification(InternalResponse::createNotification("Runtime.exceptionThrown", std::move(messageData)));
+}
+
+void Frontend::exceptionRevoked(const String& reason, int exceptionId)
+{
+    if (!m_frontendChannel)
+        return;
+    std::unique_ptr<ExceptionRevokedNotification> messageData = ExceptionRevokedNotification::create()
+        .setReason(reason)
+        .setExceptionId(exceptionId)
+        .build();
+    m_frontendChannel->sendProtocolNotification(InternalResponse::createNotification("Runtime.exceptionRevoked", std::move(messageData)));
+}
+
+void Frontend::consoleAPICalled(const String& type, std::unique_ptr<protocol::Array<protocol::Runtime::RemoteObject>> args, int executionContextId, double timestamp, Maybe<protocol::Runtime::StackTrace> stackTrace)
+{
+    if (!m_frontendChannel)
+        return;
+    std::unique_ptr<ConsoleAPICalledNotification> messageData = ConsoleAPICalledNotification::create()
+        .setType(type)
+        .setArgs(std::move(args))
+        .setExecutionContextId(executionContextId)
+        .setTimestamp(timestamp)
+        .build();
+    if (stackTrace.isJust())
+        messageData->setStackTrace(std::move(stackTrace).takeJust());
+    m_frontendChannel->sendProtocolNotification(InternalResponse::createNotification("Runtime.consoleAPICalled", std::move(messageData)));
+}
+
+void Frontend::inspectRequested(std::unique_ptr<protocol::Runtime::RemoteObject> object, std::unique_ptr<protocol::DictionaryValue> hints)
+{
+    if (!m_frontendChannel)
+        return;
+    std::unique_ptr<InspectRequestedNotification> messageData = InspectRequestedNotification::create()
+        .setObject(std::move(object))
+        .setHints(std::move(hints))
+        .build();
+    m_frontendChannel->sendProtocolNotification(InternalResponse::createNotification("Runtime.inspectRequested", std::move(messageData)));
+}
+
+void Frontend::flush()
+{
+    m_frontendChannel->flushProtocolNotifications();
+}
+
+void Frontend::sendRawNotification(const String& notification)
+{
+    m_frontendChannel->sendProtocolNotification(InternalRawNotification::create(notification));
+}
+
+// --------------------- Dispatcher.
+
+class DispatcherImpl : public protocol::DispatcherBase {
+public:
+    DispatcherImpl(FrontendChannel* frontendChannel, Backend* backend, bool fallThroughForNotFound)
+        : DispatcherBase(frontendChannel)
+        , m_backend(backend)
+        , m_fallThroughForNotFound(fallThroughForNotFound) {
+        m_dispatchMap["Runtime.evaluate"] = &DispatcherImpl::evaluate;
+        m_dispatchMap["Runtime.awaitPromise"] = &DispatcherImpl::awaitPromise;
+        m_dispatchMap["Runtime.callFunctionOn"] = &DispatcherImpl::callFunctionOn;
+        m_dispatchMap["Runtime.getProperties"] = &DispatcherImpl::getProperties;
+        m_dispatchMap["Runtime.releaseObject"] = &DispatcherImpl::releaseObject;
+        m_dispatchMap["Runtime.releaseObjectGroup"] = &DispatcherImpl::releaseObjectGroup;
+        m_dispatchMap["Runtime.runIfWaitingForDebugger"] = &DispatcherImpl::runIfWaitingForDebugger;
+        m_dispatchMap["Runtime.enable"] = &DispatcherImpl::enable;
+        m_dispatchMap["Runtime.disable"] = &DispatcherImpl::disable;
+        m_dispatchMap["Runtime.discardConsoleEntries"] = &DispatcherImpl::discardConsoleEntries;
+        m_dispatchMap["Runtime.setCustomObjectFormatterEnabled"] = &DispatcherImpl::setCustomObjectFormatterEnabled;
+        m_dispatchMap["Runtime.compileScript"] = &DispatcherImpl::compileScript;
+        m_dispatchMap["Runtime.runScript"] = &DispatcherImpl::runScript;
+    }
+    ~DispatcherImpl() override { }
+    DispatchResponse::Status dispatch(int callId, const String& method, std::unique_ptr<protocol::DictionaryValue> messageObject) override;
+    HashMap<String, String>& redirects() { return m_redirects; }
+
+protected:
+    using CallHandler = DispatchResponse::Status (DispatcherImpl::*)(int callId, std::unique_ptr<DictionaryValue> messageObject, ErrorSupport* errors);
+    using DispatchMap = protocol::HashMap<String, CallHandler>;
+    DispatchMap m_dispatchMap;
+    HashMap<String, String> m_redirects;
+
+    DispatchResponse::Status evaluate(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport*);
+    DispatchResponse::Status awaitPromise(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport*);
+    DispatchResponse::Status callFunctionOn(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport*);
+    DispatchResponse::Status getProperties(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport*);
+    DispatchResponse::Status releaseObject(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport*);
+    DispatchResponse::Status releaseObjectGroup(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport*);
+    DispatchResponse::Status runIfWaitingForDebugger(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport*);
+    DispatchResponse::Status enable(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport*);
+    DispatchResponse::Status disable(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport*);
+    DispatchResponse::Status discardConsoleEntries(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport*);
+    DispatchResponse::Status setCustomObjectFormatterEnabled(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport*);
+    DispatchResponse::Status compileScript(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport*);
+    DispatchResponse::Status runScript(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport*);
+
+    Backend* m_backend;
+    bool m_fallThroughForNotFound;
+};
+
+DispatchResponse::Status DispatcherImpl::dispatch(int callId, const String& method, std::unique_ptr<protocol::DictionaryValue> messageObject)
+{
+    protocol::HashMap<String, CallHandler>::iterator it = m_dispatchMap.find(method);
+    if (it == m_dispatchMap.end()) {
+        if (m_fallThroughForNotFound)
+            return DispatchResponse::kFallThrough;
+        reportProtocolError(callId, DispatchResponse::kMethodNotFound, "'" + method + "' wasn't found", nullptr);
+        return DispatchResponse::kError;
+    }
+
+    protocol::ErrorSupport errors;
+    return (this->*(it->second))(callId, std::move(messageObject), &errors);
+}
+
+
+class EvaluateCallbackImpl : public Backend::EvaluateCallback, public DispatcherBase::Callback {
+public:
+    EvaluateCallbackImpl(std::unique_ptr<DispatcherBase::WeakPtr> backendImpl, int callId, int callbackId)
+        : DispatcherBase::Callback(std::move(backendImpl), callId, callbackId) { }
+
+    void sendSuccess(std::unique_ptr<protocol::Runtime::RemoteObject> result, Maybe<protocol::Runtime::ExceptionDetails> exceptionDetails) override
+    {
+        std::unique_ptr<protocol::DictionaryValue> resultObject = DictionaryValue::create();
+        resultObject->setValue("result", ValueConversions<protocol::Runtime::RemoteObject>::toValue(result.get()));
+        if (exceptionDetails.isJust())
+            resultObject->setValue("exceptionDetails", ValueConversions<protocol::Runtime::ExceptionDetails>::toValue(exceptionDetails.fromJust()));
+        sendIfActive(std::move(resultObject), DispatchResponse::OK());
+    }
+
+    void fallThrough() override
+    {
+        fallThroughIfActive();
+    }
+
+    void sendFailure(const DispatchResponse& response) override
+    {
+        DCHECK(response.status() == DispatchResponse::kError);
+        sendIfActive(nullptr, response);
+    }
+};
+
+DispatchResponse::Status DispatcherImpl::evaluate(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport* errors)
+{
+    // Prepare input parameters.
+    protocol::DictionaryValue* object = DictionaryValue::cast(requestMessageObject->get("params"));
+    errors->push();
+    protocol::Value* expressionValue = object ? object->get("expression") : nullptr;
+    errors->setName("expression");
+    String in_expression = ValueConversions<String>::fromValue(expressionValue, errors);
+    protocol::Value* objectGroupValue = object ? object->get("objectGroup") : nullptr;
+    Maybe<String> in_objectGroup;
+    if (objectGroupValue) {
+        errors->setName("objectGroup");
+        in_objectGroup = ValueConversions<String>::fromValue(objectGroupValue, errors);
+    }
+    protocol::Value* includeCommandLineAPIValue = object ? object->get("includeCommandLineAPI") : nullptr;
+    Maybe<bool> in_includeCommandLineAPI;
+    if (includeCommandLineAPIValue) {
+        errors->setName("includeCommandLineAPI");
+        in_includeCommandLineAPI = ValueConversions<bool>::fromValue(includeCommandLineAPIValue, errors);
+    }
+    protocol::Value* silentValue = object ? object->get("silent") : nullptr;
+    Maybe<bool> in_silent;
+    if (silentValue) {
+        errors->setName("silent");
+        in_silent = ValueConversions<bool>::fromValue(silentValue, errors);
+    }
+    protocol::Value* contextIdValue = object ? object->get("contextId") : nullptr;
+    Maybe<int> in_contextId;
+    if (contextIdValue) {
+        errors->setName("contextId");
+        in_contextId = ValueConversions<int>::fromValue(contextIdValue, errors);
+    }
+    protocol::Value* returnByValueValue = object ? object->get("returnByValue") : nullptr;
+    Maybe<bool> in_returnByValue;
+    if (returnByValueValue) {
+        errors->setName("returnByValue");
+        in_returnByValue = ValueConversions<bool>::fromValue(returnByValueValue, errors);
+    }
+    protocol::Value* generatePreviewValue = object ? object->get("generatePreview") : nullptr;
+    Maybe<bool> in_generatePreview;
+    if (generatePreviewValue) {
+        errors->setName("generatePreview");
+        in_generatePreview = ValueConversions<bool>::fromValue(generatePreviewValue, errors);
+    }
+    protocol::Value* userGestureValue = object ? object->get("userGesture") : nullptr;
+    Maybe<bool> in_userGesture;
+    if (userGestureValue) {
+        errors->setName("userGesture");
+        in_userGesture = ValueConversions<bool>::fromValue(userGestureValue, errors);
+    }
+    protocol::Value* awaitPromiseValue = object ? object->get("awaitPromise") : nullptr;
+    Maybe<bool> in_awaitPromise;
+    if (awaitPromiseValue) {
+        errors->setName("awaitPromise");
+        in_awaitPromise = ValueConversions<bool>::fromValue(awaitPromiseValue, errors);
+    }
+    errors->pop();
+    if (errors->hasErrors()) {
+        reportProtocolError(callId, DispatchResponse::kInvalidParams, kInvalidParamsString, errors);
+        return DispatchResponse::kError;
+    }
+
+    std::unique_ptr<DispatcherBase::WeakPtr> weak = weakPtr();
+    std::unique_ptr<EvaluateCallbackImpl> callback(new EvaluateCallbackImpl(weakPtr(), callId, nextCallbackId()));
+    m_backend->evaluate(in_expression, std::move(in_objectGroup), std::move(in_includeCommandLineAPI), std::move(in_silent), std::move(in_contextId), std::move(in_returnByValue), std::move(in_generatePreview), std::move(in_userGesture), std::move(in_awaitPromise), std::move(callback));
+    return (weak->get() && weak->get()->lastCallbackFallThrough()) ? DispatchResponse::kFallThrough : DispatchResponse::kAsync;
+}
+
+class AwaitPromiseCallbackImpl : public Backend::AwaitPromiseCallback, public DispatcherBase::Callback {
+public:
+    AwaitPromiseCallbackImpl(std::unique_ptr<DispatcherBase::WeakPtr> backendImpl, int callId, int callbackId)
+        : DispatcherBase::Callback(std::move(backendImpl), callId, callbackId) { }
+
+    void sendSuccess(std::unique_ptr<protocol::Runtime::RemoteObject> result, Maybe<protocol::Runtime::ExceptionDetails> exceptionDetails) override
+    {
+        std::unique_ptr<protocol::DictionaryValue> resultObject = DictionaryValue::create();
+        resultObject->setValue("result", ValueConversions<protocol::Runtime::RemoteObject>::toValue(result.get()));
+        if (exceptionDetails.isJust())
+            resultObject->setValue("exceptionDetails", ValueConversions<protocol::Runtime::ExceptionDetails>::toValue(exceptionDetails.fromJust()));
+        sendIfActive(std::move(resultObject), DispatchResponse::OK());
+    }
+
+    void fallThrough() override
+    {
+        fallThroughIfActive();
+    }
+
+    void sendFailure(const DispatchResponse& response) override
+    {
+        DCHECK(response.status() == DispatchResponse::kError);
+        sendIfActive(nullptr, response);
+    }
+};
+
+DispatchResponse::Status DispatcherImpl::awaitPromise(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport* errors)
+{
+    // Prepare input parameters.
+    protocol::DictionaryValue* object = DictionaryValue::cast(requestMessageObject->get("params"));
+    errors->push();
+    protocol::Value* promiseObjectIdValue = object ? object->get("promiseObjectId") : nullptr;
+    errors->setName("promiseObjectId");
+    String in_promiseObjectId = ValueConversions<String>::fromValue(promiseObjectIdValue, errors);
+    protocol::Value* returnByValueValue = object ? object->get("returnByValue") : nullptr;
+    Maybe<bool> in_returnByValue;
+    if (returnByValueValue) {
+        errors->setName("returnByValue");
+        in_returnByValue = ValueConversions<bool>::fromValue(returnByValueValue, errors);
+    }
+    protocol::Value* generatePreviewValue = object ? object->get("generatePreview") : nullptr;
+    Maybe<bool> in_generatePreview;
+    if (generatePreviewValue) {
+        errors->setName("generatePreview");
+        in_generatePreview = ValueConversions<bool>::fromValue(generatePreviewValue, errors);
+    }
+    errors->pop();
+    if (errors->hasErrors()) {
+        reportProtocolError(callId, DispatchResponse::kInvalidParams, kInvalidParamsString, errors);
+        return DispatchResponse::kError;
+    }
+
+    std::unique_ptr<DispatcherBase::WeakPtr> weak = weakPtr();
+    std::unique_ptr<AwaitPromiseCallbackImpl> callback(new AwaitPromiseCallbackImpl(weakPtr(), callId, nextCallbackId()));
+    m_backend->awaitPromise(in_promiseObjectId, std::move(in_returnByValue), std::move(in_generatePreview), std::move(callback));
+    return (weak->get() && weak->get()->lastCallbackFallThrough()) ? DispatchResponse::kFallThrough : DispatchResponse::kAsync;
+}
+
+class CallFunctionOnCallbackImpl : public Backend::CallFunctionOnCallback, public DispatcherBase::Callback {
+public:
+    CallFunctionOnCallbackImpl(std::unique_ptr<DispatcherBase::WeakPtr> backendImpl, int callId, int callbackId)
+        : DispatcherBase::Callback(std::move(backendImpl), callId, callbackId) { }
+
+    void sendSuccess(std::unique_ptr<protocol::Runtime::RemoteObject> result, Maybe<protocol::Runtime::ExceptionDetails> exceptionDetails) override
+    {
+        std::unique_ptr<protocol::DictionaryValue> resultObject = DictionaryValue::create();
+        resultObject->setValue("result", ValueConversions<protocol::Runtime::RemoteObject>::toValue(result.get()));
+        if (exceptionDetails.isJust())
+            resultObject->setValue("exceptionDetails", ValueConversions<protocol::Runtime::ExceptionDetails>::toValue(exceptionDetails.fromJust()));
+        sendIfActive(std::move(resultObject), DispatchResponse::OK());
+    }
+
+    void fallThrough() override
+    {
+        fallThroughIfActive();
+    }
+
+    void sendFailure(const DispatchResponse& response) override
+    {
+        DCHECK(response.status() == DispatchResponse::kError);
+        sendIfActive(nullptr, response);
+    }
+};
+
+DispatchResponse::Status DispatcherImpl::callFunctionOn(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport* errors)
+{
+    // Prepare input parameters.
+    protocol::DictionaryValue* object = DictionaryValue::cast(requestMessageObject->get("params"));
+    errors->push();
+    protocol::Value* objectIdValue = object ? object->get("objectId") : nullptr;
+    errors->setName("objectId");
+    String in_objectId = ValueConversions<String>::fromValue(objectIdValue, errors);
+    protocol::Value* functionDeclarationValue = object ? object->get("functionDeclaration") : nullptr;
+    errors->setName("functionDeclaration");
+    String in_functionDeclaration = ValueConversions<String>::fromValue(functionDeclarationValue, errors);
+    protocol::Value* argumentsValue = object ? object->get("arguments") : nullptr;
+    Maybe<protocol::Array<protocol::Runtime::CallArgument>> in_arguments;
+    if (argumentsValue) {
+        errors->setName("arguments");
+        in_arguments = ValueConversions<protocol::Array<protocol::Runtime::CallArgument>>::fromValue(argumentsValue, errors);
+    }
+    protocol::Value* silentValue = object ? object->get("silent") : nullptr;
+    Maybe<bool> in_silent;
+    if (silentValue) {
+        errors->setName("silent");
+        in_silent = ValueConversions<bool>::fromValue(silentValue, errors);
+    }
+    protocol::Value* returnByValueValue = object ? object->get("returnByValue") : nullptr;
+    Maybe<bool> in_returnByValue;
+    if (returnByValueValue) {
+        errors->setName("returnByValue");
+        in_returnByValue = ValueConversions<bool>::fromValue(returnByValueValue, errors);
+    }
+    protocol::Value* generatePreviewValue = object ? object->get("generatePreview") : nullptr;
+    Maybe<bool> in_generatePreview;
+    if (generatePreviewValue) {
+        errors->setName("generatePreview");
+        in_generatePreview = ValueConversions<bool>::fromValue(generatePreviewValue, errors);
+    }
+    protocol::Value* userGestureValue = object ? object->get("userGesture") : nullptr;
+    Maybe<bool> in_userGesture;
+    if (userGestureValue) {
+        errors->setName("userGesture");
+        in_userGesture = ValueConversions<bool>::fromValue(userGestureValue, errors);
+    }
+    protocol::Value* awaitPromiseValue = object ? object->get("awaitPromise") : nullptr;
+    Maybe<bool> in_awaitPromise;
+    if (awaitPromiseValue) {
+        errors->setName("awaitPromise");
+        in_awaitPromise = ValueConversions<bool>::fromValue(awaitPromiseValue, errors);
+    }
+    errors->pop();
+    if (errors->hasErrors()) {
+        reportProtocolError(callId, DispatchResponse::kInvalidParams, kInvalidParamsString, errors);
+        return DispatchResponse::kError;
+    }
+
+    std::unique_ptr<DispatcherBase::WeakPtr> weak = weakPtr();
+    std::unique_ptr<CallFunctionOnCallbackImpl> callback(new CallFunctionOnCallbackImpl(weakPtr(), callId, nextCallbackId()));
+    m_backend->callFunctionOn(in_objectId, in_functionDeclaration, std::move(in_arguments), std::move(in_silent), std::move(in_returnByValue), std::move(in_generatePreview), std::move(in_userGesture), std::move(in_awaitPromise), std::move(callback));
+    return (weak->get() && weak->get()->lastCallbackFallThrough()) ? DispatchResponse::kFallThrough : DispatchResponse::kAsync;
+}
+
+DispatchResponse::Status DispatcherImpl::getProperties(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport* errors)
+{
+    // Prepare input parameters.
+    protocol::DictionaryValue* object = DictionaryValue::cast(requestMessageObject->get("params"));
+    errors->push();
+    protocol::Value* objectIdValue = object ? object->get("objectId") : nullptr;
+    errors->setName("objectId");
+    String in_objectId = ValueConversions<String>::fromValue(objectIdValue, errors);
+    protocol::Value* ownPropertiesValue = object ? object->get("ownProperties") : nullptr;
+    Maybe<bool> in_ownProperties;
+    if (ownPropertiesValue) {
+        errors->setName("ownProperties");
+        in_ownProperties = ValueConversions<bool>::fromValue(ownPropertiesValue, errors);
+    }
+    protocol::Value* accessorPropertiesOnlyValue = object ? object->get("accessorPropertiesOnly") : nullptr;
+    Maybe<bool> in_accessorPropertiesOnly;
+    if (accessorPropertiesOnlyValue) {
+        errors->setName("accessorPropertiesOnly");
+        in_accessorPropertiesOnly = ValueConversions<bool>::fromValue(accessorPropertiesOnlyValue, errors);
+    }
+    protocol::Value* generatePreviewValue = object ? object->get("generatePreview") : nullptr;
+    Maybe<bool> in_generatePreview;
+    if (generatePreviewValue) {
+        errors->setName("generatePreview");
+        in_generatePreview = ValueConversions<bool>::fromValue(generatePreviewValue, errors);
+    }
+    errors->pop();
+    if (errors->hasErrors()) {
+        reportProtocolError(callId, DispatchResponse::kInvalidParams, kInvalidParamsString, errors);
+        return DispatchResponse::kError;
+    }
+    // Declare output parameters.
+    std::unique_ptr<protocol::Array<protocol::Runtime::PropertyDescriptor>> out_result;
+    Maybe<protocol::Array<protocol::Runtime::InternalPropertyDescriptor>> out_internalProperties;
+    Maybe<protocol::Runtime::ExceptionDetails> out_exceptionDetails;
+
+    std::unique_ptr<DispatcherBase::WeakPtr> weak = weakPtr();
+    DispatchResponse response = m_backend->getProperties(in_objectId, std::move(in_ownProperties), std::move(in_accessorPropertiesOnly), std::move(in_generatePreview), &out_result, &out_internalProperties, &out_exceptionDetails);
+    if (response.status() == DispatchResponse::kFallThrough)
+        return response.status();
+    std::unique_ptr<protocol::DictionaryValue> result = DictionaryValue::create();
+    if (response.status() == DispatchResponse::kSuccess) {
+        result->setValue("result", ValueConversions<protocol::Array<protocol::Runtime::PropertyDescriptor>>::toValue(out_result.get()));
+        if (out_internalProperties.isJust())
+            result->setValue("internalProperties", ValueConversions<protocol::Array<protocol::Runtime::InternalPropertyDescriptor>>::toValue(out_internalProperties.fromJust()));
+        if (out_exceptionDetails.isJust())
+            result->setValue("exceptionDetails", ValueConversions<protocol::Runtime::ExceptionDetails>::toValue(out_exceptionDetails.fromJust()));
+    }
+    if (weak->get())
+        weak->get()->sendResponse(callId, response, std::move(result));
+    return response.status();
+}
+
+DispatchResponse::Status DispatcherImpl::releaseObject(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport* errors)
+{
+    // Prepare input parameters.
+    protocol::DictionaryValue* object = DictionaryValue::cast(requestMessageObject->get("params"));
+    errors->push();
+    protocol::Value* objectIdValue = object ? object->get("objectId") : nullptr;
+    errors->setName("objectId");
+    String in_objectId = ValueConversions<String>::fromValue(objectIdValue, errors);
+    errors->pop();
+    if (errors->hasErrors()) {
+        reportProtocolError(callId, DispatchResponse::kInvalidParams, kInvalidParamsString, errors);
+        return DispatchResponse::kError;
+    }
+
+    std::unique_ptr<DispatcherBase::WeakPtr> weak = weakPtr();
+    DispatchResponse response = m_backend->releaseObject(in_objectId);
+    if (response.status() == DispatchResponse::kFallThrough)
+        return response.status();
+    if (weak->get())
+        weak->get()->sendResponse(callId, response);
+    return response.status();
+}
+
+DispatchResponse::Status DispatcherImpl::releaseObjectGroup(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport* errors)
+{
+    // Prepare input parameters.
+    protocol::DictionaryValue* object = DictionaryValue::cast(requestMessageObject->get("params"));
+    errors->push();
+    protocol::Value* objectGroupValue = object ? object->get("objectGroup") : nullptr;
+    errors->setName("objectGroup");
+    String in_objectGroup = ValueConversions<String>::fromValue(objectGroupValue, errors);
+    errors->pop();
+    if (errors->hasErrors()) {
+        reportProtocolError(callId, DispatchResponse::kInvalidParams, kInvalidParamsString, errors);
+        return DispatchResponse::kError;
+    }
+
+    std::unique_ptr<DispatcherBase::WeakPtr> weak = weakPtr();
+    DispatchResponse response = m_backend->releaseObjectGroup(in_objectGroup);
+    if (response.status() == DispatchResponse::kFallThrough)
+        return response.status();
+    if (weak->get())
+        weak->get()->sendResponse(callId, response);
+    return response.status();
+}
+
+DispatchResponse::Status DispatcherImpl::runIfWaitingForDebugger(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport* errors)
+{
+
+    std::unique_ptr<DispatcherBase::WeakPtr> weak = weakPtr();
+    DispatchResponse response = m_backend->runIfWaitingForDebugger();
+    if (response.status() == DispatchResponse::kFallThrough)
+        return response.status();
+    if (weak->get())
+        weak->get()->sendResponse(callId, response);
+    return response.status();
+}
+
+DispatchResponse::Status DispatcherImpl::enable(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport* errors)
+{
+
+    std::unique_ptr<DispatcherBase::WeakPtr> weak = weakPtr();
+    DispatchResponse response = m_backend->enable();
+    if (response.status() == DispatchResponse::kFallThrough)
+        return response.status();
+    if (weak->get())
+        weak->get()->sendResponse(callId, response);
+    return response.status();
+}
+
+DispatchResponse::Status DispatcherImpl::disable(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport* errors)
+{
+
+    std::unique_ptr<DispatcherBase::WeakPtr> weak = weakPtr();
+    DispatchResponse response = m_backend->disable();
+    if (response.status() == DispatchResponse::kFallThrough)
+        return response.status();
+    if (weak->get())
+        weak->get()->sendResponse(callId, response);
+    return response.status();
+}
+
+DispatchResponse::Status DispatcherImpl::discardConsoleEntries(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport* errors)
+{
+
+    std::unique_ptr<DispatcherBase::WeakPtr> weak = weakPtr();
+    DispatchResponse response = m_backend->discardConsoleEntries();
+    if (response.status() == DispatchResponse::kFallThrough)
+        return response.status();
+    if (weak->get())
+        weak->get()->sendResponse(callId, response);
+    return response.status();
+}
+
+DispatchResponse::Status DispatcherImpl::setCustomObjectFormatterEnabled(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport* errors)
+{
+    // Prepare input parameters.
+    protocol::DictionaryValue* object = DictionaryValue::cast(requestMessageObject->get("params"));
+    errors->push();
+    protocol::Value* enabledValue = object ? object->get("enabled") : nullptr;
+    errors->setName("enabled");
+    bool in_enabled = ValueConversions<bool>::fromValue(enabledValue, errors);
+    errors->pop();
+    if (errors->hasErrors()) {
+        reportProtocolError(callId, DispatchResponse::kInvalidParams, kInvalidParamsString, errors);
+        return DispatchResponse::kError;
+    }
+
+    std::unique_ptr<DispatcherBase::WeakPtr> weak = weakPtr();
+    DispatchResponse response = m_backend->setCustomObjectFormatterEnabled(in_enabled);
+    if (response.status() == DispatchResponse::kFallThrough)
+        return response.status();
+    if (weak->get())
+        weak->get()->sendResponse(callId, response);
+    return response.status();
+}
+
+DispatchResponse::Status DispatcherImpl::compileScript(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport* errors)
+{
+    // Prepare input parameters.
+    protocol::DictionaryValue* object = DictionaryValue::cast(requestMessageObject->get("params"));
+    errors->push();
+    protocol::Value* expressionValue = object ? object->get("expression") : nullptr;
+    errors->setName("expression");
+    String in_expression = ValueConversions<String>::fromValue(expressionValue, errors);
+    protocol::Value* sourceURLValue = object ? object->get("sourceURL") : nullptr;
+    errors->setName("sourceURL");
+    String in_sourceURL = ValueConversions<String>::fromValue(sourceURLValue, errors);
+    protocol::Value* persistScriptValue = object ? object->get("persistScript") : nullptr;
+    errors->setName("persistScript");
+    bool in_persistScript = ValueConversions<bool>::fromValue(persistScriptValue, errors);
+    protocol::Value* executionContextIdValue = object ? object->get("executionContextId") : nullptr;
+    Maybe<int> in_executionContextId;
+    if (executionContextIdValue) {
+        errors->setName("executionContextId");
+        in_executionContextId = ValueConversions<int>::fromValue(executionContextIdValue, errors);
+    }
+    errors->pop();
+    if (errors->hasErrors()) {
+        reportProtocolError(callId, DispatchResponse::kInvalidParams, kInvalidParamsString, errors);
+        return DispatchResponse::kError;
+    }
+    // Declare output parameters.
+    Maybe<String> out_scriptId;
+    Maybe<protocol::Runtime::ExceptionDetails> out_exceptionDetails;
+
+    std::unique_ptr<DispatcherBase::WeakPtr> weak = weakPtr();
+    DispatchResponse response = m_backend->compileScript(in_expression, in_sourceURL, in_persistScript, std::move(in_executionContextId), &out_scriptId, &out_exceptionDetails);
+    if (response.status() == DispatchResponse::kFallThrough)
+        return response.status();
+    std::unique_ptr<protocol::DictionaryValue> result = DictionaryValue::create();
+    if (response.status() == DispatchResponse::kSuccess) {
+        if (out_scriptId.isJust())
+            result->setValue("scriptId", ValueConversions<String>::toValue(out_scriptId.fromJust()));
+        if (out_exceptionDetails.isJust())
+            result->setValue("exceptionDetails", ValueConversions<protocol::Runtime::ExceptionDetails>::toValue(out_exceptionDetails.fromJust()));
+    }
+    if (weak->get())
+        weak->get()->sendResponse(callId, response, std::move(result));
+    return response.status();
+}
+
+class RunScriptCallbackImpl : public Backend::RunScriptCallback, public DispatcherBase::Callback {
+public:
+    RunScriptCallbackImpl(std::unique_ptr<DispatcherBase::WeakPtr> backendImpl, int callId, int callbackId)
+        : DispatcherBase::Callback(std::move(backendImpl), callId, callbackId) { }
+
+    void sendSuccess(std::unique_ptr<protocol::Runtime::RemoteObject> result, Maybe<protocol::Runtime::ExceptionDetails> exceptionDetails) override
+    {
+        std::unique_ptr<protocol::DictionaryValue> resultObject = DictionaryValue::create();
+        resultObject->setValue("result", ValueConversions<protocol::Runtime::RemoteObject>::toValue(result.get()));
+        if (exceptionDetails.isJust())
+            resultObject->setValue("exceptionDetails", ValueConversions<protocol::Runtime::ExceptionDetails>::toValue(exceptionDetails.fromJust()));
+        sendIfActive(std::move(resultObject), DispatchResponse::OK());
+    }
+
+    void fallThrough() override
+    {
+        fallThroughIfActive();
+    }
+
+    void sendFailure(const DispatchResponse& response) override
+    {
+        DCHECK(response.status() == DispatchResponse::kError);
+        sendIfActive(nullptr, response);
+    }
+};
+
+DispatchResponse::Status DispatcherImpl::runScript(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport* errors)
+{
+    // Prepare input parameters.
+    protocol::DictionaryValue* object = DictionaryValue::cast(requestMessageObject->get("params"));
+    errors->push();
+    protocol::Value* scriptIdValue = object ? object->get("scriptId") : nullptr;
+    errors->setName("scriptId");
+    String in_scriptId = ValueConversions<String>::fromValue(scriptIdValue, errors);
+    protocol::Value* executionContextIdValue = object ? object->get("executionContextId") : nullptr;
+    Maybe<int> in_executionContextId;
+    if (executionContextIdValue) {
+        errors->setName("executionContextId");
+        in_executionContextId = ValueConversions<int>::fromValue(executionContextIdValue, errors);
+    }
+    protocol::Value* objectGroupValue = object ? object->get("objectGroup") : nullptr;
+    Maybe<String> in_objectGroup;
+    if (objectGroupValue) {
+        errors->setName("objectGroup");
+        in_objectGroup = ValueConversions<String>::fromValue(objectGroupValue, errors);
+    }
+    protocol::Value* silentValue = object ? object->get("silent") : nullptr;
+    Maybe<bool> in_silent;
+    if (silentValue) {
+        errors->setName("silent");
+        in_silent = ValueConversions<bool>::fromValue(silentValue, errors);
+    }
+    protocol::Value* includeCommandLineAPIValue = object ? object->get("includeCommandLineAPI") : nullptr;
+    Maybe<bool> in_includeCommandLineAPI;
+    if (includeCommandLineAPIValue) {
+        errors->setName("includeCommandLineAPI");
+        in_includeCommandLineAPI = ValueConversions<bool>::fromValue(includeCommandLineAPIValue, errors);
+    }
+    protocol::Value* returnByValueValue = object ? object->get("returnByValue") : nullptr;
+    Maybe<bool> in_returnByValue;
+    if (returnByValueValue) {
+        errors->setName("returnByValue");
+        in_returnByValue = ValueConversions<bool>::fromValue(returnByValueValue, errors);
+    }
+    protocol::Value* generatePreviewValue = object ? object->get("generatePreview") : nullptr;
+    Maybe<bool> in_generatePreview;
+    if (generatePreviewValue) {
+        errors->setName("generatePreview");
+        in_generatePreview = ValueConversions<bool>::fromValue(generatePreviewValue, errors);
+    }
+    protocol::Value* awaitPromiseValue = object ? object->get("awaitPromise") : nullptr;
+    Maybe<bool> in_awaitPromise;
+    if (awaitPromiseValue) {
+        errors->setName("awaitPromise");
+        in_awaitPromise = ValueConversions<bool>::fromValue(awaitPromiseValue, errors);
+    }
+    errors->pop();
+    if (errors->hasErrors()) {
+        reportProtocolError(callId, DispatchResponse::kInvalidParams, kInvalidParamsString, errors);
+        return DispatchResponse::kError;
+    }
+
+    std::unique_ptr<DispatcherBase::WeakPtr> weak = weakPtr();
+    std::unique_ptr<RunScriptCallbackImpl> callback(new RunScriptCallbackImpl(weakPtr(), callId, nextCallbackId()));
+    m_backend->runScript(in_scriptId, std::move(in_executionContextId), std::move(in_objectGroup), std::move(in_silent), std::move(in_includeCommandLineAPI), std::move(in_returnByValue), std::move(in_generatePreview), std::move(in_awaitPromise), std::move(callback));
+    return (weak->get() && weak->get()->lastCallbackFallThrough()) ? DispatchResponse::kFallThrough : DispatchResponse::kAsync;
+}
+
+// static
+void Dispatcher::wire(UberDispatcher* uber, Backend* backend)
+{
+    std::unique_ptr<DispatcherImpl> dispatcher(new DispatcherImpl(uber->channel(), backend, uber->fallThroughForNotFound()));
+    uber->setupRedirects(dispatcher->redirects());
+    uber->registerBackend("Runtime", std::move(dispatcher));
+}
+
+} // Runtime
+} // namespace JsDebug
+} // namespace protocol

--- a/lib/Debug.Protocol/Generated/protocol/Runtime.h
+++ b/lib/Debug.Protocol/Generated/protocol/Runtime.h
@@ -1,0 +1,2055 @@
+// This file is generated
+
+// Copyright (c) 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef JsDebug_protocol_Runtime_h
+#define JsDebug_protocol_Runtime_h
+
+#include "protocol/Protocol.h"
+// For each imported domain we generate a ValueConversions struct instead of a full domain definition
+// and include Domain::API version from there.
+#include "include/Runtime.h"
+
+namespace JsDebug {
+namespace protocol {
+namespace Runtime {
+
+// ------------- Forward and enum declarations.
+using ScriptId = String;
+using RemoteObjectId = String;
+using UnserializableValue = String;
+class RemoteObject;
+class CustomPreview;
+class ObjectPreview;
+class PropertyPreview;
+class EntryPreview;
+class PropertyDescriptor;
+class InternalPropertyDescriptor;
+class CallArgument;
+using ExecutionContextId = int;
+class ExecutionContextDescription;
+class ExceptionDetails;
+using Timestamp = double;
+class CallFrame;
+class StackTrace;
+class ExecutionContextCreatedNotification;
+class ExecutionContextDestroyedNotification;
+using ExecutionContextsClearedNotification = Object;
+class ExceptionThrownNotification;
+class ExceptionRevokedNotification;
+class ConsoleAPICalledNotification;
+class InspectRequestedNotification;
+
+namespace UnserializableValueEnum {
+ extern const char Infinity[];
+ extern const char NaN[];
+ extern const char NegativeInfinity[];
+ extern const char Negative0[];
+} // namespace UnserializableValueEnum
+
+namespace ConsoleAPICalled {
+namespace TypeEnum {
+ extern const char* Log;
+ extern const char* Debug;
+ extern const char* Info;
+ extern const char* Error;
+ extern const char* Warning;
+ extern const char* Dir;
+ extern const char* Dirxml;
+ extern const char* Table;
+ extern const char* Trace;
+ extern const char* Clear;
+ extern const char* StartGroup;
+ extern const char* StartGroupCollapsed;
+ extern const char* EndGroup;
+ extern const char* Assert;
+ extern const char* Profile;
+ extern const char* ProfileEnd;
+} // TypeEnum
+} // ConsoleAPICalled
+
+// ------------- Type and builder declarations.
+
+class  RemoteObject : public Serializable, public API::RemoteObject{
+    PROTOCOL_DISALLOW_COPY(RemoteObject);
+public:
+    static std::unique_ptr<RemoteObject> fromValue(protocol::Value* value, ErrorSupport* errors);
+
+    ~RemoteObject() override { }
+
+    struct  TypeEnum {
+        static const char* Object;
+        static const char* Function;
+        static const char* Undefined;
+        static const char* String;
+        static const char* Number;
+        static const char* Boolean;
+        static const char* Symbol;
+    }; // TypeEnum
+
+    String getType() { return m_type; }
+    void setType(const String& value) { m_type = value; }
+
+    struct  SubtypeEnum {
+        static const char* Array;
+        static const char* Null;
+        static const char* Node;
+        static const char* Regexp;
+        static const char* Date;
+        static const char* Map;
+        static const char* Set;
+        static const char* Iterator;
+        static const char* Generator;
+        static const char* Error;
+        static const char* Proxy;
+        static const char* Promise;
+        static const char* Typedarray;
+    }; // SubtypeEnum
+
+    bool hasSubtype() { return m_subtype.isJust(); }
+    String getSubtype(const String& defaultValue) { return m_subtype.isJust() ? m_subtype.fromJust() : defaultValue; }
+    void setSubtype(const String& value) { m_subtype = value; }
+
+    bool hasClassName() { return m_className.isJust(); }
+    String getClassName(const String& defaultValue) { return m_className.isJust() ? m_className.fromJust() : defaultValue; }
+    void setClassName(const String& value) { m_className = value; }
+
+    bool hasValue() { return m_value.isJust(); }
+    protocol::Value* getValue(protocol::Value* defaultValue) { return m_value.isJust() ? m_value.fromJust() : defaultValue; }
+    void setValue(std::unique_ptr<protocol::Value> value) { m_value = std::move(value); }
+
+    bool hasUnserializableValue() { return m_unserializableValue.isJust(); }
+    String getUnserializableValue(const String& defaultValue) { return m_unserializableValue.isJust() ? m_unserializableValue.fromJust() : defaultValue; }
+    void setUnserializableValue(const String& value) { m_unserializableValue = value; }
+
+    bool hasDescription() { return m_description.isJust(); }
+    String getDescription(const String& defaultValue) { return m_description.isJust() ? m_description.fromJust() : defaultValue; }
+    void setDescription(const String& value) { m_description = value; }
+
+    bool hasObjectId() { return m_objectId.isJust(); }
+    String getObjectId(const String& defaultValue) { return m_objectId.isJust() ? m_objectId.fromJust() : defaultValue; }
+    void setObjectId(const String& value) { m_objectId = value; }
+
+    bool hasPreview() { return m_preview.isJust(); }
+    protocol::Runtime::ObjectPreview* getPreview(protocol::Runtime::ObjectPreview* defaultValue) { return m_preview.isJust() ? m_preview.fromJust() : defaultValue; }
+    void setPreview(std::unique_ptr<protocol::Runtime::ObjectPreview> value) { m_preview = std::move(value); }
+
+    bool hasCustomPreview() { return m_customPreview.isJust(); }
+    protocol::Runtime::CustomPreview* getCustomPreview(protocol::Runtime::CustomPreview* defaultValue) { return m_customPreview.isJust() ? m_customPreview.fromJust() : defaultValue; }
+    void setCustomPreview(std::unique_ptr<protocol::Runtime::CustomPreview> value) { m_customPreview = std::move(value); }
+
+    std::unique_ptr<protocol::DictionaryValue> toValue() const;
+    String serialize() override { return toValue()->serialize(); }
+    std::unique_ptr<RemoteObject> clone() const;
+    std::unique_ptr<StringBuffer> toJSONString() const override;
+
+    template<int STATE>
+    class RemoteObjectBuilder {
+    public:
+        enum {
+            NoFieldsSet = 0,
+            TypeSet = 1 << 1,
+            AllFieldsSet = (TypeSet | 0)};
+
+
+        RemoteObjectBuilder<STATE | TypeSet>& setType(const String& value)
+        {
+            static_assert(!(STATE & TypeSet), "property type should not be set yet");
+            m_result->setType(value);
+            return castState<TypeSet>();
+        }
+
+        RemoteObjectBuilder<STATE>& setSubtype(const String& value)
+        {
+            m_result->setSubtype(value);
+            return *this;
+        }
+
+        RemoteObjectBuilder<STATE>& setClassName(const String& value)
+        {
+            m_result->setClassName(value);
+            return *this;
+        }
+
+        RemoteObjectBuilder<STATE>& setValue(std::unique_ptr<protocol::Value> value)
+        {
+            m_result->setValue(std::move(value));
+            return *this;
+        }
+
+        RemoteObjectBuilder<STATE>& setUnserializableValue(const String& value)
+        {
+            m_result->setUnserializableValue(value);
+            return *this;
+        }
+
+        RemoteObjectBuilder<STATE>& setDescription(const String& value)
+        {
+            m_result->setDescription(value);
+            return *this;
+        }
+
+        RemoteObjectBuilder<STATE>& setObjectId(const String& value)
+        {
+            m_result->setObjectId(value);
+            return *this;
+        }
+
+        RemoteObjectBuilder<STATE>& setPreview(std::unique_ptr<protocol::Runtime::ObjectPreview> value)
+        {
+            m_result->setPreview(std::move(value));
+            return *this;
+        }
+
+        RemoteObjectBuilder<STATE>& setCustomPreview(std::unique_ptr<protocol::Runtime::CustomPreview> value)
+        {
+            m_result->setCustomPreview(std::move(value));
+            return *this;
+        }
+
+        std::unique_ptr<RemoteObject> build()
+        {
+            static_assert(STATE == AllFieldsSet, "state should be AllFieldsSet");
+            return std::move(m_result);
+        }
+
+    private:
+        friend class RemoteObject;
+        RemoteObjectBuilder() : m_result(new RemoteObject()) { }
+
+        template<int STEP> RemoteObjectBuilder<STATE | STEP>& castState()
+        {
+            return *reinterpret_cast<RemoteObjectBuilder<STATE | STEP>*>(this);
+        }
+
+        std::unique_ptr<protocol::Runtime::RemoteObject> m_result;
+    };
+
+    static RemoteObjectBuilder<0> create()
+    {
+        return RemoteObjectBuilder<0>();
+    }
+
+private:
+    RemoteObject()
+    {
+    }
+
+    String m_type;
+    Maybe<String> m_subtype;
+    Maybe<String> m_className;
+    Maybe<protocol::Value> m_value;
+    Maybe<String> m_unserializableValue;
+    Maybe<String> m_description;
+    Maybe<String> m_objectId;
+    Maybe<protocol::Runtime::ObjectPreview> m_preview;
+    Maybe<protocol::Runtime::CustomPreview> m_customPreview;
+};
+
+
+class  CustomPreview : public Serializable{
+    PROTOCOL_DISALLOW_COPY(CustomPreview);
+public:
+    static std::unique_ptr<CustomPreview> fromValue(protocol::Value* value, ErrorSupport* errors);
+
+    ~CustomPreview() override { }
+
+    String getHeader() { return m_header; }
+    void setHeader(const String& value) { m_header = value; }
+
+    bool getHasBody() { return m_hasBody; }
+    void setHasBody(bool value) { m_hasBody = value; }
+
+    String getFormatterObjectId() { return m_formatterObjectId; }
+    void setFormatterObjectId(const String& value) { m_formatterObjectId = value; }
+
+    String getBindRemoteObjectFunctionId() { return m_bindRemoteObjectFunctionId; }
+    void setBindRemoteObjectFunctionId(const String& value) { m_bindRemoteObjectFunctionId = value; }
+
+    bool hasConfigObjectId() { return m_configObjectId.isJust(); }
+    String getConfigObjectId(const String& defaultValue) { return m_configObjectId.isJust() ? m_configObjectId.fromJust() : defaultValue; }
+    void setConfigObjectId(const String& value) { m_configObjectId = value; }
+
+    std::unique_ptr<protocol::DictionaryValue> toValue() const;
+    String serialize() override { return toValue()->serialize(); }
+    std::unique_ptr<CustomPreview> clone() const;
+
+    template<int STATE>
+    class CustomPreviewBuilder {
+    public:
+        enum {
+            NoFieldsSet = 0,
+            HeaderSet = 1 << 1,
+            HasBodySet = 1 << 2,
+            FormatterObjectIdSet = 1 << 3,
+            BindRemoteObjectFunctionIdSet = 1 << 4,
+            AllFieldsSet = (HeaderSet | HasBodySet | FormatterObjectIdSet | BindRemoteObjectFunctionIdSet | 0)};
+
+
+        CustomPreviewBuilder<STATE | HeaderSet>& setHeader(const String& value)
+        {
+            static_assert(!(STATE & HeaderSet), "property header should not be set yet");
+            m_result->setHeader(value);
+            return castState<HeaderSet>();
+        }
+
+        CustomPreviewBuilder<STATE | HasBodySet>& setHasBody(bool value)
+        {
+            static_assert(!(STATE & HasBodySet), "property hasBody should not be set yet");
+            m_result->setHasBody(value);
+            return castState<HasBodySet>();
+        }
+
+        CustomPreviewBuilder<STATE | FormatterObjectIdSet>& setFormatterObjectId(const String& value)
+        {
+            static_assert(!(STATE & FormatterObjectIdSet), "property formatterObjectId should not be set yet");
+            m_result->setFormatterObjectId(value);
+            return castState<FormatterObjectIdSet>();
+        }
+
+        CustomPreviewBuilder<STATE | BindRemoteObjectFunctionIdSet>& setBindRemoteObjectFunctionId(const String& value)
+        {
+            static_assert(!(STATE & BindRemoteObjectFunctionIdSet), "property bindRemoteObjectFunctionId should not be set yet");
+            m_result->setBindRemoteObjectFunctionId(value);
+            return castState<BindRemoteObjectFunctionIdSet>();
+        }
+
+        CustomPreviewBuilder<STATE>& setConfigObjectId(const String& value)
+        {
+            m_result->setConfigObjectId(value);
+            return *this;
+        }
+
+        std::unique_ptr<CustomPreview> build()
+        {
+            static_assert(STATE == AllFieldsSet, "state should be AllFieldsSet");
+            return std::move(m_result);
+        }
+
+    private:
+        friend class CustomPreview;
+        CustomPreviewBuilder() : m_result(new CustomPreview()) { }
+
+        template<int STEP> CustomPreviewBuilder<STATE | STEP>& castState()
+        {
+            return *reinterpret_cast<CustomPreviewBuilder<STATE | STEP>*>(this);
+        }
+
+        std::unique_ptr<protocol::Runtime::CustomPreview> m_result;
+    };
+
+    static CustomPreviewBuilder<0> create()
+    {
+        return CustomPreviewBuilder<0>();
+    }
+
+private:
+    CustomPreview()
+    {
+          m_hasBody = false;
+    }
+
+    String m_header;
+    bool m_hasBody;
+    String m_formatterObjectId;
+    String m_bindRemoteObjectFunctionId;
+    Maybe<String> m_configObjectId;
+};
+
+
+class  ObjectPreview : public Serializable{
+    PROTOCOL_DISALLOW_COPY(ObjectPreview);
+public:
+    static std::unique_ptr<ObjectPreview> fromValue(protocol::Value* value, ErrorSupport* errors);
+
+    ~ObjectPreview() override { }
+
+    struct  TypeEnum {
+        static const char* Object;
+        static const char* Function;
+        static const char* Undefined;
+        static const char* String;
+        static const char* Number;
+        static const char* Boolean;
+        static const char* Symbol;
+    }; // TypeEnum
+
+    String getType() { return m_type; }
+    void setType(const String& value) { m_type = value; }
+
+    struct  SubtypeEnum {
+        static const char* Array;
+        static const char* Null;
+        static const char* Node;
+        static const char* Regexp;
+        static const char* Date;
+        static const char* Map;
+        static const char* Set;
+        static const char* Iterator;
+        static const char* Generator;
+        static const char* Error;
+    }; // SubtypeEnum
+
+    bool hasSubtype() { return m_subtype.isJust(); }
+    String getSubtype(const String& defaultValue) { return m_subtype.isJust() ? m_subtype.fromJust() : defaultValue; }
+    void setSubtype(const String& value) { m_subtype = value; }
+
+    bool hasDescription() { return m_description.isJust(); }
+    String getDescription(const String& defaultValue) { return m_description.isJust() ? m_description.fromJust() : defaultValue; }
+    void setDescription(const String& value) { m_description = value; }
+
+    bool getOverflow() { return m_overflow; }
+    void setOverflow(bool value) { m_overflow = value; }
+
+    protocol::Array<protocol::Runtime::PropertyPreview>* getProperties() { return m_properties.get(); }
+    void setProperties(std::unique_ptr<protocol::Array<protocol::Runtime::PropertyPreview>> value) { m_properties = std::move(value); }
+
+    bool hasEntries() { return m_entries.isJust(); }
+    protocol::Array<protocol::Runtime::EntryPreview>* getEntries(protocol::Array<protocol::Runtime::EntryPreview>* defaultValue) { return m_entries.isJust() ? m_entries.fromJust() : defaultValue; }
+    void setEntries(std::unique_ptr<protocol::Array<protocol::Runtime::EntryPreview>> value) { m_entries = std::move(value); }
+
+    std::unique_ptr<protocol::DictionaryValue> toValue() const;
+    String serialize() override { return toValue()->serialize(); }
+    std::unique_ptr<ObjectPreview> clone() const;
+
+    template<int STATE>
+    class ObjectPreviewBuilder {
+    public:
+        enum {
+            NoFieldsSet = 0,
+            TypeSet = 1 << 1,
+            OverflowSet = 1 << 2,
+            PropertiesSet = 1 << 3,
+            AllFieldsSet = (TypeSet | OverflowSet | PropertiesSet | 0)};
+
+
+        ObjectPreviewBuilder<STATE | TypeSet>& setType(const String& value)
+        {
+            static_assert(!(STATE & TypeSet), "property type should not be set yet");
+            m_result->setType(value);
+            return castState<TypeSet>();
+        }
+
+        ObjectPreviewBuilder<STATE>& setSubtype(const String& value)
+        {
+            m_result->setSubtype(value);
+            return *this;
+        }
+
+        ObjectPreviewBuilder<STATE>& setDescription(const String& value)
+        {
+            m_result->setDescription(value);
+            return *this;
+        }
+
+        ObjectPreviewBuilder<STATE | OverflowSet>& setOverflow(bool value)
+        {
+            static_assert(!(STATE & OverflowSet), "property overflow should not be set yet");
+            m_result->setOverflow(value);
+            return castState<OverflowSet>();
+        }
+
+        ObjectPreviewBuilder<STATE | PropertiesSet>& setProperties(std::unique_ptr<protocol::Array<protocol::Runtime::PropertyPreview>> value)
+        {
+            static_assert(!(STATE & PropertiesSet), "property properties should not be set yet");
+            m_result->setProperties(std::move(value));
+            return castState<PropertiesSet>();
+        }
+
+        ObjectPreviewBuilder<STATE>& setEntries(std::unique_ptr<protocol::Array<protocol::Runtime::EntryPreview>> value)
+        {
+            m_result->setEntries(std::move(value));
+            return *this;
+        }
+
+        std::unique_ptr<ObjectPreview> build()
+        {
+            static_assert(STATE == AllFieldsSet, "state should be AllFieldsSet");
+            return std::move(m_result);
+        }
+
+    private:
+        friend class ObjectPreview;
+        ObjectPreviewBuilder() : m_result(new ObjectPreview()) { }
+
+        template<int STEP> ObjectPreviewBuilder<STATE | STEP>& castState()
+        {
+            return *reinterpret_cast<ObjectPreviewBuilder<STATE | STEP>*>(this);
+        }
+
+        std::unique_ptr<protocol::Runtime::ObjectPreview> m_result;
+    };
+
+    static ObjectPreviewBuilder<0> create()
+    {
+        return ObjectPreviewBuilder<0>();
+    }
+
+private:
+    ObjectPreview()
+    {
+          m_overflow = false;
+    }
+
+    String m_type;
+    Maybe<String> m_subtype;
+    Maybe<String> m_description;
+    bool m_overflow;
+    std::unique_ptr<protocol::Array<protocol::Runtime::PropertyPreview>> m_properties;
+    Maybe<protocol::Array<protocol::Runtime::EntryPreview>> m_entries;
+};
+
+
+class  PropertyPreview : public Serializable{
+    PROTOCOL_DISALLOW_COPY(PropertyPreview);
+public:
+    static std::unique_ptr<PropertyPreview> fromValue(protocol::Value* value, ErrorSupport* errors);
+
+    ~PropertyPreview() override { }
+
+    String getName() { return m_name; }
+    void setName(const String& value) { m_name = value; }
+
+    struct  TypeEnum {
+        static const char* Object;
+        static const char* Function;
+        static const char* Undefined;
+        static const char* String;
+        static const char* Number;
+        static const char* Boolean;
+        static const char* Symbol;
+        static const char* Accessor;
+    }; // TypeEnum
+
+    String getType() { return m_type; }
+    void setType(const String& value) { m_type = value; }
+
+    bool hasValue() { return m_value.isJust(); }
+    String getValue(const String& defaultValue) { return m_value.isJust() ? m_value.fromJust() : defaultValue; }
+    void setValue(const String& value) { m_value = value; }
+
+    bool hasValuePreview() { return m_valuePreview.isJust(); }
+    protocol::Runtime::ObjectPreview* getValuePreview(protocol::Runtime::ObjectPreview* defaultValue) { return m_valuePreview.isJust() ? m_valuePreview.fromJust() : defaultValue; }
+    void setValuePreview(std::unique_ptr<protocol::Runtime::ObjectPreview> value) { m_valuePreview = std::move(value); }
+
+    struct  SubtypeEnum {
+        static const char* Array;
+        static const char* Null;
+        static const char* Node;
+        static const char* Regexp;
+        static const char* Date;
+        static const char* Map;
+        static const char* Set;
+        static const char* Iterator;
+        static const char* Generator;
+        static const char* Error;
+    }; // SubtypeEnum
+
+    bool hasSubtype() { return m_subtype.isJust(); }
+    String getSubtype(const String& defaultValue) { return m_subtype.isJust() ? m_subtype.fromJust() : defaultValue; }
+    void setSubtype(const String& value) { m_subtype = value; }
+
+    std::unique_ptr<protocol::DictionaryValue> toValue() const;
+    String serialize() override { return toValue()->serialize(); }
+    std::unique_ptr<PropertyPreview> clone() const;
+
+    template<int STATE>
+    class PropertyPreviewBuilder {
+    public:
+        enum {
+            NoFieldsSet = 0,
+            NameSet = 1 << 1,
+            TypeSet = 1 << 2,
+            AllFieldsSet = (NameSet | TypeSet | 0)};
+
+
+        PropertyPreviewBuilder<STATE | NameSet>& setName(const String& value)
+        {
+            static_assert(!(STATE & NameSet), "property name should not be set yet");
+            m_result->setName(value);
+            return castState<NameSet>();
+        }
+
+        PropertyPreviewBuilder<STATE | TypeSet>& setType(const String& value)
+        {
+            static_assert(!(STATE & TypeSet), "property type should not be set yet");
+            m_result->setType(value);
+            return castState<TypeSet>();
+        }
+
+        PropertyPreviewBuilder<STATE>& setValue(const String& value)
+        {
+            m_result->setValue(value);
+            return *this;
+        }
+
+        PropertyPreviewBuilder<STATE>& setValuePreview(std::unique_ptr<protocol::Runtime::ObjectPreview> value)
+        {
+            m_result->setValuePreview(std::move(value));
+            return *this;
+        }
+
+        PropertyPreviewBuilder<STATE>& setSubtype(const String& value)
+        {
+            m_result->setSubtype(value);
+            return *this;
+        }
+
+        std::unique_ptr<PropertyPreview> build()
+        {
+            static_assert(STATE == AllFieldsSet, "state should be AllFieldsSet");
+            return std::move(m_result);
+        }
+
+    private:
+        friend class PropertyPreview;
+        PropertyPreviewBuilder() : m_result(new PropertyPreview()) { }
+
+        template<int STEP> PropertyPreviewBuilder<STATE | STEP>& castState()
+        {
+            return *reinterpret_cast<PropertyPreviewBuilder<STATE | STEP>*>(this);
+        }
+
+        std::unique_ptr<protocol::Runtime::PropertyPreview> m_result;
+    };
+
+    static PropertyPreviewBuilder<0> create()
+    {
+        return PropertyPreviewBuilder<0>();
+    }
+
+private:
+    PropertyPreview()
+    {
+    }
+
+    String m_name;
+    String m_type;
+    Maybe<String> m_value;
+    Maybe<protocol::Runtime::ObjectPreview> m_valuePreview;
+    Maybe<String> m_subtype;
+};
+
+
+class  EntryPreview : public Serializable{
+    PROTOCOL_DISALLOW_COPY(EntryPreview);
+public:
+    static std::unique_ptr<EntryPreview> fromValue(protocol::Value* value, ErrorSupport* errors);
+
+    ~EntryPreview() override { }
+
+    bool hasKey() { return m_key.isJust(); }
+    protocol::Runtime::ObjectPreview* getKey(protocol::Runtime::ObjectPreview* defaultValue) { return m_key.isJust() ? m_key.fromJust() : defaultValue; }
+    void setKey(std::unique_ptr<protocol::Runtime::ObjectPreview> value) { m_key = std::move(value); }
+
+    protocol::Runtime::ObjectPreview* getValue() { return m_value.get(); }
+    void setValue(std::unique_ptr<protocol::Runtime::ObjectPreview> value) { m_value = std::move(value); }
+
+    std::unique_ptr<protocol::DictionaryValue> toValue() const;
+    String serialize() override { return toValue()->serialize(); }
+    std::unique_ptr<EntryPreview> clone() const;
+
+    template<int STATE>
+    class EntryPreviewBuilder {
+    public:
+        enum {
+            NoFieldsSet = 0,
+            ValueSet = 1 << 1,
+            AllFieldsSet = (ValueSet | 0)};
+
+
+        EntryPreviewBuilder<STATE>& setKey(std::unique_ptr<protocol::Runtime::ObjectPreview> value)
+        {
+            m_result->setKey(std::move(value));
+            return *this;
+        }
+
+        EntryPreviewBuilder<STATE | ValueSet>& setValue(std::unique_ptr<protocol::Runtime::ObjectPreview> value)
+        {
+            static_assert(!(STATE & ValueSet), "property value should not be set yet");
+            m_result->setValue(std::move(value));
+            return castState<ValueSet>();
+        }
+
+        std::unique_ptr<EntryPreview> build()
+        {
+            static_assert(STATE == AllFieldsSet, "state should be AllFieldsSet");
+            return std::move(m_result);
+        }
+
+    private:
+        friend class EntryPreview;
+        EntryPreviewBuilder() : m_result(new EntryPreview()) { }
+
+        template<int STEP> EntryPreviewBuilder<STATE | STEP>& castState()
+        {
+            return *reinterpret_cast<EntryPreviewBuilder<STATE | STEP>*>(this);
+        }
+
+        std::unique_ptr<protocol::Runtime::EntryPreview> m_result;
+    };
+
+    static EntryPreviewBuilder<0> create()
+    {
+        return EntryPreviewBuilder<0>();
+    }
+
+private:
+    EntryPreview()
+    {
+    }
+
+    Maybe<protocol::Runtime::ObjectPreview> m_key;
+    std::unique_ptr<protocol::Runtime::ObjectPreview> m_value;
+};
+
+
+class  PropertyDescriptor : public Serializable{
+    PROTOCOL_DISALLOW_COPY(PropertyDescriptor);
+public:
+    static std::unique_ptr<PropertyDescriptor> fromValue(protocol::Value* value, ErrorSupport* errors);
+
+    ~PropertyDescriptor() override { }
+
+    String getName() { return m_name; }
+    void setName(const String& value) { m_name = value; }
+
+    bool hasValue() { return m_value.isJust(); }
+    protocol::Runtime::RemoteObject* getValue(protocol::Runtime::RemoteObject* defaultValue) { return m_value.isJust() ? m_value.fromJust() : defaultValue; }
+    void setValue(std::unique_ptr<protocol::Runtime::RemoteObject> value) { m_value = std::move(value); }
+
+    bool hasWritable() { return m_writable.isJust(); }
+    bool getWritable(bool defaultValue) { return m_writable.isJust() ? m_writable.fromJust() : defaultValue; }
+    void setWritable(bool value) { m_writable = value; }
+
+    bool hasGet() { return m_get.isJust(); }
+    protocol::Runtime::RemoteObject* getGet(protocol::Runtime::RemoteObject* defaultValue) { return m_get.isJust() ? m_get.fromJust() : defaultValue; }
+    void setGet(std::unique_ptr<protocol::Runtime::RemoteObject> value) { m_get = std::move(value); }
+
+    bool hasSet() { return m_set.isJust(); }
+    protocol::Runtime::RemoteObject* getSet(protocol::Runtime::RemoteObject* defaultValue) { return m_set.isJust() ? m_set.fromJust() : defaultValue; }
+    void setSet(std::unique_ptr<protocol::Runtime::RemoteObject> value) { m_set = std::move(value); }
+
+    bool getConfigurable() { return m_configurable; }
+    void setConfigurable(bool value) { m_configurable = value; }
+
+    bool getEnumerable() { return m_enumerable; }
+    void setEnumerable(bool value) { m_enumerable = value; }
+
+    bool hasWasThrown() { return m_wasThrown.isJust(); }
+    bool getWasThrown(bool defaultValue) { return m_wasThrown.isJust() ? m_wasThrown.fromJust() : defaultValue; }
+    void setWasThrown(bool value) { m_wasThrown = value; }
+
+    bool hasIsOwn() { return m_isOwn.isJust(); }
+    bool getIsOwn(bool defaultValue) { return m_isOwn.isJust() ? m_isOwn.fromJust() : defaultValue; }
+    void setIsOwn(bool value) { m_isOwn = value; }
+
+    bool hasSymbol() { return m_symbol.isJust(); }
+    protocol::Runtime::RemoteObject* getSymbol(protocol::Runtime::RemoteObject* defaultValue) { return m_symbol.isJust() ? m_symbol.fromJust() : defaultValue; }
+    void setSymbol(std::unique_ptr<protocol::Runtime::RemoteObject> value) { m_symbol = std::move(value); }
+
+    std::unique_ptr<protocol::DictionaryValue> toValue() const;
+    String serialize() override { return toValue()->serialize(); }
+    std::unique_ptr<PropertyDescriptor> clone() const;
+
+    template<int STATE>
+    class PropertyDescriptorBuilder {
+    public:
+        enum {
+            NoFieldsSet = 0,
+            NameSet = 1 << 1,
+            ConfigurableSet = 1 << 2,
+            EnumerableSet = 1 << 3,
+            AllFieldsSet = (NameSet | ConfigurableSet | EnumerableSet | 0)};
+
+
+        PropertyDescriptorBuilder<STATE | NameSet>& setName(const String& value)
+        {
+            static_assert(!(STATE & NameSet), "property name should not be set yet");
+            m_result->setName(value);
+            return castState<NameSet>();
+        }
+
+        PropertyDescriptorBuilder<STATE>& setValue(std::unique_ptr<protocol::Runtime::RemoteObject> value)
+        {
+            m_result->setValue(std::move(value));
+            return *this;
+        }
+
+        PropertyDescriptorBuilder<STATE>& setWritable(bool value)
+        {
+            m_result->setWritable(value);
+            return *this;
+        }
+
+        PropertyDescriptorBuilder<STATE>& setGet(std::unique_ptr<protocol::Runtime::RemoteObject> value)
+        {
+            m_result->setGet(std::move(value));
+            return *this;
+        }
+
+        PropertyDescriptorBuilder<STATE>& setSet(std::unique_ptr<protocol::Runtime::RemoteObject> value)
+        {
+            m_result->setSet(std::move(value));
+            return *this;
+        }
+
+        PropertyDescriptorBuilder<STATE | ConfigurableSet>& setConfigurable(bool value)
+        {
+            static_assert(!(STATE & ConfigurableSet), "property configurable should not be set yet");
+            m_result->setConfigurable(value);
+            return castState<ConfigurableSet>();
+        }
+
+        PropertyDescriptorBuilder<STATE | EnumerableSet>& setEnumerable(bool value)
+        {
+            static_assert(!(STATE & EnumerableSet), "property enumerable should not be set yet");
+            m_result->setEnumerable(value);
+            return castState<EnumerableSet>();
+        }
+
+        PropertyDescriptorBuilder<STATE>& setWasThrown(bool value)
+        {
+            m_result->setWasThrown(value);
+            return *this;
+        }
+
+        PropertyDescriptorBuilder<STATE>& setIsOwn(bool value)
+        {
+            m_result->setIsOwn(value);
+            return *this;
+        }
+
+        PropertyDescriptorBuilder<STATE>& setSymbol(std::unique_ptr<protocol::Runtime::RemoteObject> value)
+        {
+            m_result->setSymbol(std::move(value));
+            return *this;
+        }
+
+        std::unique_ptr<PropertyDescriptor> build()
+        {
+            static_assert(STATE == AllFieldsSet, "state should be AllFieldsSet");
+            return std::move(m_result);
+        }
+
+    private:
+        friend class PropertyDescriptor;
+        PropertyDescriptorBuilder() : m_result(new PropertyDescriptor()) { }
+
+        template<int STEP> PropertyDescriptorBuilder<STATE | STEP>& castState()
+        {
+            return *reinterpret_cast<PropertyDescriptorBuilder<STATE | STEP>*>(this);
+        }
+
+        std::unique_ptr<protocol::Runtime::PropertyDescriptor> m_result;
+    };
+
+    static PropertyDescriptorBuilder<0> create()
+    {
+        return PropertyDescriptorBuilder<0>();
+    }
+
+private:
+    PropertyDescriptor()
+    {
+          m_configurable = false;
+          m_enumerable = false;
+    }
+
+    String m_name;
+    Maybe<protocol::Runtime::RemoteObject> m_value;
+    Maybe<bool> m_writable;
+    Maybe<protocol::Runtime::RemoteObject> m_get;
+    Maybe<protocol::Runtime::RemoteObject> m_set;
+    bool m_configurable;
+    bool m_enumerable;
+    Maybe<bool> m_wasThrown;
+    Maybe<bool> m_isOwn;
+    Maybe<protocol::Runtime::RemoteObject> m_symbol;
+};
+
+
+class  InternalPropertyDescriptor : public Serializable{
+    PROTOCOL_DISALLOW_COPY(InternalPropertyDescriptor);
+public:
+    static std::unique_ptr<InternalPropertyDescriptor> fromValue(protocol::Value* value, ErrorSupport* errors);
+
+    ~InternalPropertyDescriptor() override { }
+
+    String getName() { return m_name; }
+    void setName(const String& value) { m_name = value; }
+
+    bool hasValue() { return m_value.isJust(); }
+    protocol::Runtime::RemoteObject* getValue(protocol::Runtime::RemoteObject* defaultValue) { return m_value.isJust() ? m_value.fromJust() : defaultValue; }
+    void setValue(std::unique_ptr<protocol::Runtime::RemoteObject> value) { m_value = std::move(value); }
+
+    std::unique_ptr<protocol::DictionaryValue> toValue() const;
+    String serialize() override { return toValue()->serialize(); }
+    std::unique_ptr<InternalPropertyDescriptor> clone() const;
+
+    template<int STATE>
+    class InternalPropertyDescriptorBuilder {
+    public:
+        enum {
+            NoFieldsSet = 0,
+            NameSet = 1 << 1,
+            AllFieldsSet = (NameSet | 0)};
+
+
+        InternalPropertyDescriptorBuilder<STATE | NameSet>& setName(const String& value)
+        {
+            static_assert(!(STATE & NameSet), "property name should not be set yet");
+            m_result->setName(value);
+            return castState<NameSet>();
+        }
+
+        InternalPropertyDescriptorBuilder<STATE>& setValue(std::unique_ptr<protocol::Runtime::RemoteObject> value)
+        {
+            m_result->setValue(std::move(value));
+            return *this;
+        }
+
+        std::unique_ptr<InternalPropertyDescriptor> build()
+        {
+            static_assert(STATE == AllFieldsSet, "state should be AllFieldsSet");
+            return std::move(m_result);
+        }
+
+    private:
+        friend class InternalPropertyDescriptor;
+        InternalPropertyDescriptorBuilder() : m_result(new InternalPropertyDescriptor()) { }
+
+        template<int STEP> InternalPropertyDescriptorBuilder<STATE | STEP>& castState()
+        {
+            return *reinterpret_cast<InternalPropertyDescriptorBuilder<STATE | STEP>*>(this);
+        }
+
+        std::unique_ptr<protocol::Runtime::InternalPropertyDescriptor> m_result;
+    };
+
+    static InternalPropertyDescriptorBuilder<0> create()
+    {
+        return InternalPropertyDescriptorBuilder<0>();
+    }
+
+private:
+    InternalPropertyDescriptor()
+    {
+    }
+
+    String m_name;
+    Maybe<protocol::Runtime::RemoteObject> m_value;
+};
+
+
+class  CallArgument : public Serializable{
+    PROTOCOL_DISALLOW_COPY(CallArgument);
+public:
+    static std::unique_ptr<CallArgument> fromValue(protocol::Value* value, ErrorSupport* errors);
+
+    ~CallArgument() override { }
+
+    bool hasValue() { return m_value.isJust(); }
+    protocol::Value* getValue(protocol::Value* defaultValue) { return m_value.isJust() ? m_value.fromJust() : defaultValue; }
+    void setValue(std::unique_ptr<protocol::Value> value) { m_value = std::move(value); }
+
+    bool hasUnserializableValue() { return m_unserializableValue.isJust(); }
+    String getUnserializableValue(const String& defaultValue) { return m_unserializableValue.isJust() ? m_unserializableValue.fromJust() : defaultValue; }
+    void setUnserializableValue(const String& value) { m_unserializableValue = value; }
+
+    bool hasObjectId() { return m_objectId.isJust(); }
+    String getObjectId(const String& defaultValue) { return m_objectId.isJust() ? m_objectId.fromJust() : defaultValue; }
+    void setObjectId(const String& value) { m_objectId = value; }
+
+    std::unique_ptr<protocol::DictionaryValue> toValue() const;
+    String serialize() override { return toValue()->serialize(); }
+    std::unique_ptr<CallArgument> clone() const;
+
+    template<int STATE>
+    class CallArgumentBuilder {
+    public:
+        enum {
+            NoFieldsSet = 0,
+            AllFieldsSet = (0)};
+
+
+        CallArgumentBuilder<STATE>& setValue(std::unique_ptr<protocol::Value> value)
+        {
+            m_result->setValue(std::move(value));
+            return *this;
+        }
+
+        CallArgumentBuilder<STATE>& setUnserializableValue(const String& value)
+        {
+            m_result->setUnserializableValue(value);
+            return *this;
+        }
+
+        CallArgumentBuilder<STATE>& setObjectId(const String& value)
+        {
+            m_result->setObjectId(value);
+            return *this;
+        }
+
+        std::unique_ptr<CallArgument> build()
+        {
+            static_assert(STATE == AllFieldsSet, "state should be AllFieldsSet");
+            return std::move(m_result);
+        }
+
+    private:
+        friend class CallArgument;
+        CallArgumentBuilder() : m_result(new CallArgument()) { }
+
+        template<int STEP> CallArgumentBuilder<STATE | STEP>& castState()
+        {
+            return *reinterpret_cast<CallArgumentBuilder<STATE | STEP>*>(this);
+        }
+
+        std::unique_ptr<protocol::Runtime::CallArgument> m_result;
+    };
+
+    static CallArgumentBuilder<0> create()
+    {
+        return CallArgumentBuilder<0>();
+    }
+
+private:
+    CallArgument()
+    {
+    }
+
+    Maybe<protocol::Value> m_value;
+    Maybe<String> m_unserializableValue;
+    Maybe<String> m_objectId;
+};
+
+
+class  ExecutionContextDescription : public Serializable{
+    PROTOCOL_DISALLOW_COPY(ExecutionContextDescription);
+public:
+    static std::unique_ptr<ExecutionContextDescription> fromValue(protocol::Value* value, ErrorSupport* errors);
+
+    ~ExecutionContextDescription() override { }
+
+    int getId() { return m_id; }
+    void setId(int value) { m_id = value; }
+
+    String getOrigin() { return m_origin; }
+    void setOrigin(const String& value) { m_origin = value; }
+
+    String getName() { return m_name; }
+    void setName(const String& value) { m_name = value; }
+
+    bool hasAuxData() { return m_auxData.isJust(); }
+    protocol::DictionaryValue* getAuxData(protocol::DictionaryValue* defaultValue) { return m_auxData.isJust() ? m_auxData.fromJust() : defaultValue; }
+    void setAuxData(std::unique_ptr<protocol::DictionaryValue> value) { m_auxData = std::move(value); }
+
+    std::unique_ptr<protocol::DictionaryValue> toValue() const;
+    String serialize() override { return toValue()->serialize(); }
+    std::unique_ptr<ExecutionContextDescription> clone() const;
+
+    template<int STATE>
+    class ExecutionContextDescriptionBuilder {
+    public:
+        enum {
+            NoFieldsSet = 0,
+            IdSet = 1 << 1,
+            OriginSet = 1 << 2,
+            NameSet = 1 << 3,
+            AllFieldsSet = (IdSet | OriginSet | NameSet | 0)};
+
+
+        ExecutionContextDescriptionBuilder<STATE | IdSet>& setId(int value)
+        {
+            static_assert(!(STATE & IdSet), "property id should not be set yet");
+            m_result->setId(value);
+            return castState<IdSet>();
+        }
+
+        ExecutionContextDescriptionBuilder<STATE | OriginSet>& setOrigin(const String& value)
+        {
+            static_assert(!(STATE & OriginSet), "property origin should not be set yet");
+            m_result->setOrigin(value);
+            return castState<OriginSet>();
+        }
+
+        ExecutionContextDescriptionBuilder<STATE | NameSet>& setName(const String& value)
+        {
+            static_assert(!(STATE & NameSet), "property name should not be set yet");
+            m_result->setName(value);
+            return castState<NameSet>();
+        }
+
+        ExecutionContextDescriptionBuilder<STATE>& setAuxData(std::unique_ptr<protocol::DictionaryValue> value)
+        {
+            m_result->setAuxData(std::move(value));
+            return *this;
+        }
+
+        std::unique_ptr<ExecutionContextDescription> build()
+        {
+            static_assert(STATE == AllFieldsSet, "state should be AllFieldsSet");
+            return std::move(m_result);
+        }
+
+    private:
+        friend class ExecutionContextDescription;
+        ExecutionContextDescriptionBuilder() : m_result(new ExecutionContextDescription()) { }
+
+        template<int STEP> ExecutionContextDescriptionBuilder<STATE | STEP>& castState()
+        {
+            return *reinterpret_cast<ExecutionContextDescriptionBuilder<STATE | STEP>*>(this);
+        }
+
+        std::unique_ptr<protocol::Runtime::ExecutionContextDescription> m_result;
+    };
+
+    static ExecutionContextDescriptionBuilder<0> create()
+    {
+        return ExecutionContextDescriptionBuilder<0>();
+    }
+
+private:
+    ExecutionContextDescription()
+    {
+          m_id = 0;
+    }
+
+    int m_id;
+    String m_origin;
+    String m_name;
+    Maybe<protocol::DictionaryValue> m_auxData;
+};
+
+
+class  ExceptionDetails : public Serializable{
+    PROTOCOL_DISALLOW_COPY(ExceptionDetails);
+public:
+    static std::unique_ptr<ExceptionDetails> fromValue(protocol::Value* value, ErrorSupport* errors);
+
+    ~ExceptionDetails() override { }
+
+    int getExceptionId() { return m_exceptionId; }
+    void setExceptionId(int value) { m_exceptionId = value; }
+
+    String getText() { return m_text; }
+    void setText(const String& value) { m_text = value; }
+
+    int getLineNumber() { return m_lineNumber; }
+    void setLineNumber(int value) { m_lineNumber = value; }
+
+    int getColumnNumber() { return m_columnNumber; }
+    void setColumnNumber(int value) { m_columnNumber = value; }
+
+    bool hasScriptId() { return m_scriptId.isJust(); }
+    String getScriptId(const String& defaultValue) { return m_scriptId.isJust() ? m_scriptId.fromJust() : defaultValue; }
+    void setScriptId(const String& value) { m_scriptId = value; }
+
+    bool hasUrl() { return m_url.isJust(); }
+    String getUrl(const String& defaultValue) { return m_url.isJust() ? m_url.fromJust() : defaultValue; }
+    void setUrl(const String& value) { m_url = value; }
+
+    bool hasStackTrace() { return m_stackTrace.isJust(); }
+    protocol::Runtime::StackTrace* getStackTrace(protocol::Runtime::StackTrace* defaultValue) { return m_stackTrace.isJust() ? m_stackTrace.fromJust() : defaultValue; }
+    void setStackTrace(std::unique_ptr<protocol::Runtime::StackTrace> value) { m_stackTrace = std::move(value); }
+
+    bool hasException() { return m_exception.isJust(); }
+    protocol::Runtime::RemoteObject* getException(protocol::Runtime::RemoteObject* defaultValue) { return m_exception.isJust() ? m_exception.fromJust() : defaultValue; }
+    void setException(std::unique_ptr<protocol::Runtime::RemoteObject> value) { m_exception = std::move(value); }
+
+    bool hasExecutionContextId() { return m_executionContextId.isJust(); }
+    int getExecutionContextId(int defaultValue) { return m_executionContextId.isJust() ? m_executionContextId.fromJust() : defaultValue; }
+    void setExecutionContextId(int value) { m_executionContextId = value; }
+
+    std::unique_ptr<protocol::DictionaryValue> toValue() const;
+    String serialize() override { return toValue()->serialize(); }
+    std::unique_ptr<ExceptionDetails> clone() const;
+
+    template<int STATE>
+    class ExceptionDetailsBuilder {
+    public:
+        enum {
+            NoFieldsSet = 0,
+            ExceptionIdSet = 1 << 1,
+            TextSet = 1 << 2,
+            LineNumberSet = 1 << 3,
+            ColumnNumberSet = 1 << 4,
+            AllFieldsSet = (ExceptionIdSet | TextSet | LineNumberSet | ColumnNumberSet | 0)};
+
+
+        ExceptionDetailsBuilder<STATE | ExceptionIdSet>& setExceptionId(int value)
+        {
+            static_assert(!(STATE & ExceptionIdSet), "property exceptionId should not be set yet");
+            m_result->setExceptionId(value);
+            return castState<ExceptionIdSet>();
+        }
+
+        ExceptionDetailsBuilder<STATE | TextSet>& setText(const String& value)
+        {
+            static_assert(!(STATE & TextSet), "property text should not be set yet");
+            m_result->setText(value);
+            return castState<TextSet>();
+        }
+
+        ExceptionDetailsBuilder<STATE | LineNumberSet>& setLineNumber(int value)
+        {
+            static_assert(!(STATE & LineNumberSet), "property lineNumber should not be set yet");
+            m_result->setLineNumber(value);
+            return castState<LineNumberSet>();
+        }
+
+        ExceptionDetailsBuilder<STATE | ColumnNumberSet>& setColumnNumber(int value)
+        {
+            static_assert(!(STATE & ColumnNumberSet), "property columnNumber should not be set yet");
+            m_result->setColumnNumber(value);
+            return castState<ColumnNumberSet>();
+        }
+
+        ExceptionDetailsBuilder<STATE>& setScriptId(const String& value)
+        {
+            m_result->setScriptId(value);
+            return *this;
+        }
+
+        ExceptionDetailsBuilder<STATE>& setUrl(const String& value)
+        {
+            m_result->setUrl(value);
+            return *this;
+        }
+
+        ExceptionDetailsBuilder<STATE>& setStackTrace(std::unique_ptr<protocol::Runtime::StackTrace> value)
+        {
+            m_result->setStackTrace(std::move(value));
+            return *this;
+        }
+
+        ExceptionDetailsBuilder<STATE>& setException(std::unique_ptr<protocol::Runtime::RemoteObject> value)
+        {
+            m_result->setException(std::move(value));
+            return *this;
+        }
+
+        ExceptionDetailsBuilder<STATE>& setExecutionContextId(int value)
+        {
+            m_result->setExecutionContextId(value);
+            return *this;
+        }
+
+        std::unique_ptr<ExceptionDetails> build()
+        {
+            static_assert(STATE == AllFieldsSet, "state should be AllFieldsSet");
+            return std::move(m_result);
+        }
+
+    private:
+        friend class ExceptionDetails;
+        ExceptionDetailsBuilder() : m_result(new ExceptionDetails()) { }
+
+        template<int STEP> ExceptionDetailsBuilder<STATE | STEP>& castState()
+        {
+            return *reinterpret_cast<ExceptionDetailsBuilder<STATE | STEP>*>(this);
+        }
+
+        std::unique_ptr<protocol::Runtime::ExceptionDetails> m_result;
+    };
+
+    static ExceptionDetailsBuilder<0> create()
+    {
+        return ExceptionDetailsBuilder<0>();
+    }
+
+private:
+    ExceptionDetails()
+    {
+          m_exceptionId = 0;
+          m_lineNumber = 0;
+          m_columnNumber = 0;
+    }
+
+    int m_exceptionId;
+    String m_text;
+    int m_lineNumber;
+    int m_columnNumber;
+    Maybe<String> m_scriptId;
+    Maybe<String> m_url;
+    Maybe<protocol::Runtime::StackTrace> m_stackTrace;
+    Maybe<protocol::Runtime::RemoteObject> m_exception;
+    Maybe<int> m_executionContextId;
+};
+
+
+class  CallFrame : public Serializable{
+    PROTOCOL_DISALLOW_COPY(CallFrame);
+public:
+    static std::unique_ptr<CallFrame> fromValue(protocol::Value* value, ErrorSupport* errors);
+
+    ~CallFrame() override { }
+
+    String getFunctionName() { return m_functionName; }
+    void setFunctionName(const String& value) { m_functionName = value; }
+
+    String getScriptId() { return m_scriptId; }
+    void setScriptId(const String& value) { m_scriptId = value; }
+
+    String getUrl() { return m_url; }
+    void setUrl(const String& value) { m_url = value; }
+
+    int getLineNumber() { return m_lineNumber; }
+    void setLineNumber(int value) { m_lineNumber = value; }
+
+    int getColumnNumber() { return m_columnNumber; }
+    void setColumnNumber(int value) { m_columnNumber = value; }
+
+    std::unique_ptr<protocol::DictionaryValue> toValue() const;
+    String serialize() override { return toValue()->serialize(); }
+    std::unique_ptr<CallFrame> clone() const;
+
+    template<int STATE>
+    class CallFrameBuilder {
+    public:
+        enum {
+            NoFieldsSet = 0,
+            FunctionNameSet = 1 << 1,
+            ScriptIdSet = 1 << 2,
+            UrlSet = 1 << 3,
+            LineNumberSet = 1 << 4,
+            ColumnNumberSet = 1 << 5,
+            AllFieldsSet = (FunctionNameSet | ScriptIdSet | UrlSet | LineNumberSet | ColumnNumberSet | 0)};
+
+
+        CallFrameBuilder<STATE | FunctionNameSet>& setFunctionName(const String& value)
+        {
+            static_assert(!(STATE & FunctionNameSet), "property functionName should not be set yet");
+            m_result->setFunctionName(value);
+            return castState<FunctionNameSet>();
+        }
+
+        CallFrameBuilder<STATE | ScriptIdSet>& setScriptId(const String& value)
+        {
+            static_assert(!(STATE & ScriptIdSet), "property scriptId should not be set yet");
+            m_result->setScriptId(value);
+            return castState<ScriptIdSet>();
+        }
+
+        CallFrameBuilder<STATE | UrlSet>& setUrl(const String& value)
+        {
+            static_assert(!(STATE & UrlSet), "property url should not be set yet");
+            m_result->setUrl(value);
+            return castState<UrlSet>();
+        }
+
+        CallFrameBuilder<STATE | LineNumberSet>& setLineNumber(int value)
+        {
+            static_assert(!(STATE & LineNumberSet), "property lineNumber should not be set yet");
+            m_result->setLineNumber(value);
+            return castState<LineNumberSet>();
+        }
+
+        CallFrameBuilder<STATE | ColumnNumberSet>& setColumnNumber(int value)
+        {
+            static_assert(!(STATE & ColumnNumberSet), "property columnNumber should not be set yet");
+            m_result->setColumnNumber(value);
+            return castState<ColumnNumberSet>();
+        }
+
+        std::unique_ptr<CallFrame> build()
+        {
+            static_assert(STATE == AllFieldsSet, "state should be AllFieldsSet");
+            return std::move(m_result);
+        }
+
+    private:
+        friend class CallFrame;
+        CallFrameBuilder() : m_result(new CallFrame()) { }
+
+        template<int STEP> CallFrameBuilder<STATE | STEP>& castState()
+        {
+            return *reinterpret_cast<CallFrameBuilder<STATE | STEP>*>(this);
+        }
+
+        std::unique_ptr<protocol::Runtime::CallFrame> m_result;
+    };
+
+    static CallFrameBuilder<0> create()
+    {
+        return CallFrameBuilder<0>();
+    }
+
+private:
+    CallFrame()
+    {
+          m_lineNumber = 0;
+          m_columnNumber = 0;
+    }
+
+    String m_functionName;
+    String m_scriptId;
+    String m_url;
+    int m_lineNumber;
+    int m_columnNumber;
+};
+
+
+class  StackTrace : public Serializable, public API::StackTrace{
+    PROTOCOL_DISALLOW_COPY(StackTrace);
+public:
+    static std::unique_ptr<StackTrace> fromValue(protocol::Value* value, ErrorSupport* errors);
+
+    ~StackTrace() override { }
+
+    bool hasDescription() { return m_description.isJust(); }
+    String getDescription(const String& defaultValue) { return m_description.isJust() ? m_description.fromJust() : defaultValue; }
+    void setDescription(const String& value) { m_description = value; }
+
+    protocol::Array<protocol::Runtime::CallFrame>* getCallFrames() { return m_callFrames.get(); }
+    void setCallFrames(std::unique_ptr<protocol::Array<protocol::Runtime::CallFrame>> value) { m_callFrames = std::move(value); }
+
+    bool hasParent() { return m_parent.isJust(); }
+    protocol::Runtime::StackTrace* getParent(protocol::Runtime::StackTrace* defaultValue) { return m_parent.isJust() ? m_parent.fromJust() : defaultValue; }
+    void setParent(std::unique_ptr<protocol::Runtime::StackTrace> value) { m_parent = std::move(value); }
+
+    std::unique_ptr<protocol::DictionaryValue> toValue() const;
+    String serialize() override { return toValue()->serialize(); }
+    std::unique_ptr<StackTrace> clone() const;
+    std::unique_ptr<StringBuffer> toJSONString() const override;
+
+    template<int STATE>
+    class StackTraceBuilder {
+    public:
+        enum {
+            NoFieldsSet = 0,
+            CallFramesSet = 1 << 1,
+            AllFieldsSet = (CallFramesSet | 0)};
+
+
+        StackTraceBuilder<STATE>& setDescription(const String& value)
+        {
+            m_result->setDescription(value);
+            return *this;
+        }
+
+        StackTraceBuilder<STATE | CallFramesSet>& setCallFrames(std::unique_ptr<protocol::Array<protocol::Runtime::CallFrame>> value)
+        {
+            static_assert(!(STATE & CallFramesSet), "property callFrames should not be set yet");
+            m_result->setCallFrames(std::move(value));
+            return castState<CallFramesSet>();
+        }
+
+        StackTraceBuilder<STATE>& setParent(std::unique_ptr<protocol::Runtime::StackTrace> value)
+        {
+            m_result->setParent(std::move(value));
+            return *this;
+        }
+
+        std::unique_ptr<StackTrace> build()
+        {
+            static_assert(STATE == AllFieldsSet, "state should be AllFieldsSet");
+            return std::move(m_result);
+        }
+
+    private:
+        friend class StackTrace;
+        StackTraceBuilder() : m_result(new StackTrace()) { }
+
+        template<int STEP> StackTraceBuilder<STATE | STEP>& castState()
+        {
+            return *reinterpret_cast<StackTraceBuilder<STATE | STEP>*>(this);
+        }
+
+        std::unique_ptr<protocol::Runtime::StackTrace> m_result;
+    };
+
+    static StackTraceBuilder<0> create()
+    {
+        return StackTraceBuilder<0>();
+    }
+
+private:
+    StackTrace()
+    {
+    }
+
+    Maybe<String> m_description;
+    std::unique_ptr<protocol::Array<protocol::Runtime::CallFrame>> m_callFrames;
+    Maybe<protocol::Runtime::StackTrace> m_parent;
+};
+
+
+class  ExecutionContextCreatedNotification : public Serializable{
+    PROTOCOL_DISALLOW_COPY(ExecutionContextCreatedNotification);
+public:
+    static std::unique_ptr<ExecutionContextCreatedNotification> fromValue(protocol::Value* value, ErrorSupport* errors);
+
+    ~ExecutionContextCreatedNotification() override { }
+
+    protocol::Runtime::ExecutionContextDescription* getContext() { return m_context.get(); }
+    void setContext(std::unique_ptr<protocol::Runtime::ExecutionContextDescription> value) { m_context = std::move(value); }
+
+    std::unique_ptr<protocol::DictionaryValue> toValue() const;
+    String serialize() override { return toValue()->serialize(); }
+    std::unique_ptr<ExecutionContextCreatedNotification> clone() const;
+
+    template<int STATE>
+    class ExecutionContextCreatedNotificationBuilder {
+    public:
+        enum {
+            NoFieldsSet = 0,
+            ContextSet = 1 << 1,
+            AllFieldsSet = (ContextSet | 0)};
+
+
+        ExecutionContextCreatedNotificationBuilder<STATE | ContextSet>& setContext(std::unique_ptr<protocol::Runtime::ExecutionContextDescription> value)
+        {
+            static_assert(!(STATE & ContextSet), "property context should not be set yet");
+            m_result->setContext(std::move(value));
+            return castState<ContextSet>();
+        }
+
+        std::unique_ptr<ExecutionContextCreatedNotification> build()
+        {
+            static_assert(STATE == AllFieldsSet, "state should be AllFieldsSet");
+            return std::move(m_result);
+        }
+
+    private:
+        friend class ExecutionContextCreatedNotification;
+        ExecutionContextCreatedNotificationBuilder() : m_result(new ExecutionContextCreatedNotification()) { }
+
+        template<int STEP> ExecutionContextCreatedNotificationBuilder<STATE | STEP>& castState()
+        {
+            return *reinterpret_cast<ExecutionContextCreatedNotificationBuilder<STATE | STEP>*>(this);
+        }
+
+        std::unique_ptr<protocol::Runtime::ExecutionContextCreatedNotification> m_result;
+    };
+
+    static ExecutionContextCreatedNotificationBuilder<0> create()
+    {
+        return ExecutionContextCreatedNotificationBuilder<0>();
+    }
+
+private:
+    ExecutionContextCreatedNotification()
+    {
+    }
+
+    std::unique_ptr<protocol::Runtime::ExecutionContextDescription> m_context;
+};
+
+
+class  ExecutionContextDestroyedNotification : public Serializable{
+    PROTOCOL_DISALLOW_COPY(ExecutionContextDestroyedNotification);
+public:
+    static std::unique_ptr<ExecutionContextDestroyedNotification> fromValue(protocol::Value* value, ErrorSupport* errors);
+
+    ~ExecutionContextDestroyedNotification() override { }
+
+    int getExecutionContextId() { return m_executionContextId; }
+    void setExecutionContextId(int value) { m_executionContextId = value; }
+
+    std::unique_ptr<protocol::DictionaryValue> toValue() const;
+    String serialize() override { return toValue()->serialize(); }
+    std::unique_ptr<ExecutionContextDestroyedNotification> clone() const;
+
+    template<int STATE>
+    class ExecutionContextDestroyedNotificationBuilder {
+    public:
+        enum {
+            NoFieldsSet = 0,
+            ExecutionContextIdSet = 1 << 1,
+            AllFieldsSet = (ExecutionContextIdSet | 0)};
+
+
+        ExecutionContextDestroyedNotificationBuilder<STATE | ExecutionContextIdSet>& setExecutionContextId(int value)
+        {
+            static_assert(!(STATE & ExecutionContextIdSet), "property executionContextId should not be set yet");
+            m_result->setExecutionContextId(value);
+            return castState<ExecutionContextIdSet>();
+        }
+
+        std::unique_ptr<ExecutionContextDestroyedNotification> build()
+        {
+            static_assert(STATE == AllFieldsSet, "state should be AllFieldsSet");
+            return std::move(m_result);
+        }
+
+    private:
+        friend class ExecutionContextDestroyedNotification;
+        ExecutionContextDestroyedNotificationBuilder() : m_result(new ExecutionContextDestroyedNotification()) { }
+
+        template<int STEP> ExecutionContextDestroyedNotificationBuilder<STATE | STEP>& castState()
+        {
+            return *reinterpret_cast<ExecutionContextDestroyedNotificationBuilder<STATE | STEP>*>(this);
+        }
+
+        std::unique_ptr<protocol::Runtime::ExecutionContextDestroyedNotification> m_result;
+    };
+
+    static ExecutionContextDestroyedNotificationBuilder<0> create()
+    {
+        return ExecutionContextDestroyedNotificationBuilder<0>();
+    }
+
+private:
+    ExecutionContextDestroyedNotification()
+    {
+          m_executionContextId = 0;
+    }
+
+    int m_executionContextId;
+};
+
+
+class  ExceptionThrownNotification : public Serializable{
+    PROTOCOL_DISALLOW_COPY(ExceptionThrownNotification);
+public:
+    static std::unique_ptr<ExceptionThrownNotification> fromValue(protocol::Value* value, ErrorSupport* errors);
+
+    ~ExceptionThrownNotification() override { }
+
+    double getTimestamp() { return m_timestamp; }
+    void setTimestamp(double value) { m_timestamp = value; }
+
+    protocol::Runtime::ExceptionDetails* getExceptionDetails() { return m_exceptionDetails.get(); }
+    void setExceptionDetails(std::unique_ptr<protocol::Runtime::ExceptionDetails> value) { m_exceptionDetails = std::move(value); }
+
+    std::unique_ptr<protocol::DictionaryValue> toValue() const;
+    String serialize() override { return toValue()->serialize(); }
+    std::unique_ptr<ExceptionThrownNotification> clone() const;
+
+    template<int STATE>
+    class ExceptionThrownNotificationBuilder {
+    public:
+        enum {
+            NoFieldsSet = 0,
+            TimestampSet = 1 << 1,
+            ExceptionDetailsSet = 1 << 2,
+            AllFieldsSet = (TimestampSet | ExceptionDetailsSet | 0)};
+
+
+        ExceptionThrownNotificationBuilder<STATE | TimestampSet>& setTimestamp(double value)
+        {
+            static_assert(!(STATE & TimestampSet), "property timestamp should not be set yet");
+            m_result->setTimestamp(value);
+            return castState<TimestampSet>();
+        }
+
+        ExceptionThrownNotificationBuilder<STATE | ExceptionDetailsSet>& setExceptionDetails(std::unique_ptr<protocol::Runtime::ExceptionDetails> value)
+        {
+            static_assert(!(STATE & ExceptionDetailsSet), "property exceptionDetails should not be set yet");
+            m_result->setExceptionDetails(std::move(value));
+            return castState<ExceptionDetailsSet>();
+        }
+
+        std::unique_ptr<ExceptionThrownNotification> build()
+        {
+            static_assert(STATE == AllFieldsSet, "state should be AllFieldsSet");
+            return std::move(m_result);
+        }
+
+    private:
+        friend class ExceptionThrownNotification;
+        ExceptionThrownNotificationBuilder() : m_result(new ExceptionThrownNotification()) { }
+
+        template<int STEP> ExceptionThrownNotificationBuilder<STATE | STEP>& castState()
+        {
+            return *reinterpret_cast<ExceptionThrownNotificationBuilder<STATE | STEP>*>(this);
+        }
+
+        std::unique_ptr<protocol::Runtime::ExceptionThrownNotification> m_result;
+    };
+
+    static ExceptionThrownNotificationBuilder<0> create()
+    {
+        return ExceptionThrownNotificationBuilder<0>();
+    }
+
+private:
+    ExceptionThrownNotification()
+    {
+          m_timestamp = 0;
+    }
+
+    double m_timestamp;
+    std::unique_ptr<protocol::Runtime::ExceptionDetails> m_exceptionDetails;
+};
+
+
+class  ExceptionRevokedNotification : public Serializable{
+    PROTOCOL_DISALLOW_COPY(ExceptionRevokedNotification);
+public:
+    static std::unique_ptr<ExceptionRevokedNotification> fromValue(protocol::Value* value, ErrorSupport* errors);
+
+    ~ExceptionRevokedNotification() override { }
+
+    String getReason() { return m_reason; }
+    void setReason(const String& value) { m_reason = value; }
+
+    int getExceptionId() { return m_exceptionId; }
+    void setExceptionId(int value) { m_exceptionId = value; }
+
+    std::unique_ptr<protocol::DictionaryValue> toValue() const;
+    String serialize() override { return toValue()->serialize(); }
+    std::unique_ptr<ExceptionRevokedNotification> clone() const;
+
+    template<int STATE>
+    class ExceptionRevokedNotificationBuilder {
+    public:
+        enum {
+            NoFieldsSet = 0,
+            ReasonSet = 1 << 1,
+            ExceptionIdSet = 1 << 2,
+            AllFieldsSet = (ReasonSet | ExceptionIdSet | 0)};
+
+
+        ExceptionRevokedNotificationBuilder<STATE | ReasonSet>& setReason(const String& value)
+        {
+            static_assert(!(STATE & ReasonSet), "property reason should not be set yet");
+            m_result->setReason(value);
+            return castState<ReasonSet>();
+        }
+
+        ExceptionRevokedNotificationBuilder<STATE | ExceptionIdSet>& setExceptionId(int value)
+        {
+            static_assert(!(STATE & ExceptionIdSet), "property exceptionId should not be set yet");
+            m_result->setExceptionId(value);
+            return castState<ExceptionIdSet>();
+        }
+
+        std::unique_ptr<ExceptionRevokedNotification> build()
+        {
+            static_assert(STATE == AllFieldsSet, "state should be AllFieldsSet");
+            return std::move(m_result);
+        }
+
+    private:
+        friend class ExceptionRevokedNotification;
+        ExceptionRevokedNotificationBuilder() : m_result(new ExceptionRevokedNotification()) { }
+
+        template<int STEP> ExceptionRevokedNotificationBuilder<STATE | STEP>& castState()
+        {
+            return *reinterpret_cast<ExceptionRevokedNotificationBuilder<STATE | STEP>*>(this);
+        }
+
+        std::unique_ptr<protocol::Runtime::ExceptionRevokedNotification> m_result;
+    };
+
+    static ExceptionRevokedNotificationBuilder<0> create()
+    {
+        return ExceptionRevokedNotificationBuilder<0>();
+    }
+
+private:
+    ExceptionRevokedNotification()
+    {
+          m_exceptionId = 0;
+    }
+
+    String m_reason;
+    int m_exceptionId;
+};
+
+
+class  ConsoleAPICalledNotification : public Serializable{
+    PROTOCOL_DISALLOW_COPY(ConsoleAPICalledNotification);
+public:
+    static std::unique_ptr<ConsoleAPICalledNotification> fromValue(protocol::Value* value, ErrorSupport* errors);
+
+    ~ConsoleAPICalledNotification() override { }
+
+    struct  TypeEnum {
+        static const char* Log;
+        static const char* Debug;
+        static const char* Info;
+        static const char* Error;
+        static const char* Warning;
+        static const char* Dir;
+        static const char* Dirxml;
+        static const char* Table;
+        static const char* Trace;
+        static const char* Clear;
+        static const char* StartGroup;
+        static const char* StartGroupCollapsed;
+        static const char* EndGroup;
+        static const char* Assert;
+        static const char* Profile;
+        static const char* ProfileEnd;
+    }; // TypeEnum
+
+    String getType() { return m_type; }
+    void setType(const String& value) { m_type = value; }
+
+    protocol::Array<protocol::Runtime::RemoteObject>* getArgs() { return m_args.get(); }
+    void setArgs(std::unique_ptr<protocol::Array<protocol::Runtime::RemoteObject>> value) { m_args = std::move(value); }
+
+    int getExecutionContextId() { return m_executionContextId; }
+    void setExecutionContextId(int value) { m_executionContextId = value; }
+
+    double getTimestamp() { return m_timestamp; }
+    void setTimestamp(double value) { m_timestamp = value; }
+
+    bool hasStackTrace() { return m_stackTrace.isJust(); }
+    protocol::Runtime::StackTrace* getStackTrace(protocol::Runtime::StackTrace* defaultValue) { return m_stackTrace.isJust() ? m_stackTrace.fromJust() : defaultValue; }
+    void setStackTrace(std::unique_ptr<protocol::Runtime::StackTrace> value) { m_stackTrace = std::move(value); }
+
+    std::unique_ptr<protocol::DictionaryValue> toValue() const;
+    String serialize() override { return toValue()->serialize(); }
+    std::unique_ptr<ConsoleAPICalledNotification> clone() const;
+
+    template<int STATE>
+    class ConsoleAPICalledNotificationBuilder {
+    public:
+        enum {
+            NoFieldsSet = 0,
+            TypeSet = 1 << 1,
+            ArgsSet = 1 << 2,
+            ExecutionContextIdSet = 1 << 3,
+            TimestampSet = 1 << 4,
+            AllFieldsSet = (TypeSet | ArgsSet | ExecutionContextIdSet | TimestampSet | 0)};
+
+
+        ConsoleAPICalledNotificationBuilder<STATE | TypeSet>& setType(const String& value)
+        {
+            static_assert(!(STATE & TypeSet), "property type should not be set yet");
+            m_result->setType(value);
+            return castState<TypeSet>();
+        }
+
+        ConsoleAPICalledNotificationBuilder<STATE | ArgsSet>& setArgs(std::unique_ptr<protocol::Array<protocol::Runtime::RemoteObject>> value)
+        {
+            static_assert(!(STATE & ArgsSet), "property args should not be set yet");
+            m_result->setArgs(std::move(value));
+            return castState<ArgsSet>();
+        }
+
+        ConsoleAPICalledNotificationBuilder<STATE | ExecutionContextIdSet>& setExecutionContextId(int value)
+        {
+            static_assert(!(STATE & ExecutionContextIdSet), "property executionContextId should not be set yet");
+            m_result->setExecutionContextId(value);
+            return castState<ExecutionContextIdSet>();
+        }
+
+        ConsoleAPICalledNotificationBuilder<STATE | TimestampSet>& setTimestamp(double value)
+        {
+            static_assert(!(STATE & TimestampSet), "property timestamp should not be set yet");
+            m_result->setTimestamp(value);
+            return castState<TimestampSet>();
+        }
+
+        ConsoleAPICalledNotificationBuilder<STATE>& setStackTrace(std::unique_ptr<protocol::Runtime::StackTrace> value)
+        {
+            m_result->setStackTrace(std::move(value));
+            return *this;
+        }
+
+        std::unique_ptr<ConsoleAPICalledNotification> build()
+        {
+            static_assert(STATE == AllFieldsSet, "state should be AllFieldsSet");
+            return std::move(m_result);
+        }
+
+    private:
+        friend class ConsoleAPICalledNotification;
+        ConsoleAPICalledNotificationBuilder() : m_result(new ConsoleAPICalledNotification()) { }
+
+        template<int STEP> ConsoleAPICalledNotificationBuilder<STATE | STEP>& castState()
+        {
+            return *reinterpret_cast<ConsoleAPICalledNotificationBuilder<STATE | STEP>*>(this);
+        }
+
+        std::unique_ptr<protocol::Runtime::ConsoleAPICalledNotification> m_result;
+    };
+
+    static ConsoleAPICalledNotificationBuilder<0> create()
+    {
+        return ConsoleAPICalledNotificationBuilder<0>();
+    }
+
+private:
+    ConsoleAPICalledNotification()
+    {
+          m_executionContextId = 0;
+          m_timestamp = 0;
+    }
+
+    String m_type;
+    std::unique_ptr<protocol::Array<protocol::Runtime::RemoteObject>> m_args;
+    int m_executionContextId;
+    double m_timestamp;
+    Maybe<protocol::Runtime::StackTrace> m_stackTrace;
+};
+
+
+class  InspectRequestedNotification : public Serializable{
+    PROTOCOL_DISALLOW_COPY(InspectRequestedNotification);
+public:
+    static std::unique_ptr<InspectRequestedNotification> fromValue(protocol::Value* value, ErrorSupport* errors);
+
+    ~InspectRequestedNotification() override { }
+
+    protocol::Runtime::RemoteObject* getObject() { return m_object.get(); }
+    void setObject(std::unique_ptr<protocol::Runtime::RemoteObject> value) { m_object = std::move(value); }
+
+    protocol::DictionaryValue* getHints() { return m_hints.get(); }
+    void setHints(std::unique_ptr<protocol::DictionaryValue> value) { m_hints = std::move(value); }
+
+    std::unique_ptr<protocol::DictionaryValue> toValue() const;
+    String serialize() override { return toValue()->serialize(); }
+    std::unique_ptr<InspectRequestedNotification> clone() const;
+
+    template<int STATE>
+    class InspectRequestedNotificationBuilder {
+    public:
+        enum {
+            NoFieldsSet = 0,
+            ObjectSet = 1 << 1,
+            HintsSet = 1 << 2,
+            AllFieldsSet = (ObjectSet | HintsSet | 0)};
+
+
+        InspectRequestedNotificationBuilder<STATE | ObjectSet>& setObject(std::unique_ptr<protocol::Runtime::RemoteObject> value)
+        {
+            static_assert(!(STATE & ObjectSet), "property object should not be set yet");
+            m_result->setObject(std::move(value));
+            return castState<ObjectSet>();
+        }
+
+        InspectRequestedNotificationBuilder<STATE | HintsSet>& setHints(std::unique_ptr<protocol::DictionaryValue> value)
+        {
+            static_assert(!(STATE & HintsSet), "property hints should not be set yet");
+            m_result->setHints(std::move(value));
+            return castState<HintsSet>();
+        }
+
+        std::unique_ptr<InspectRequestedNotification> build()
+        {
+            static_assert(STATE == AllFieldsSet, "state should be AllFieldsSet");
+            return std::move(m_result);
+        }
+
+    private:
+        friend class InspectRequestedNotification;
+        InspectRequestedNotificationBuilder() : m_result(new InspectRequestedNotification()) { }
+
+        template<int STEP> InspectRequestedNotificationBuilder<STATE | STEP>& castState()
+        {
+            return *reinterpret_cast<InspectRequestedNotificationBuilder<STATE | STEP>*>(this);
+        }
+
+        std::unique_ptr<protocol::Runtime::InspectRequestedNotification> m_result;
+    };
+
+    static InspectRequestedNotificationBuilder<0> create()
+    {
+        return InspectRequestedNotificationBuilder<0>();
+    }
+
+private:
+    InspectRequestedNotification()
+    {
+    }
+
+    std::unique_ptr<protocol::Runtime::RemoteObject> m_object;
+    std::unique_ptr<protocol::DictionaryValue> m_hints;
+};
+
+
+// ------------- Backend interface.
+
+class  Backend {
+public:
+    virtual ~Backend() { }
+
+    class  EvaluateCallback {
+    public:
+        virtual void sendSuccess(std::unique_ptr<protocol::Runtime::RemoteObject> result, Maybe<protocol::Runtime::ExceptionDetails> exceptionDetails) = 0;
+        virtual void sendFailure(const DispatchResponse&) = 0;
+        virtual void fallThrough() = 0;
+        virtual ~EvaluateCallback() { }
+    };
+    virtual void evaluate(const String& in_expression, Maybe<String> in_objectGroup, Maybe<bool> in_includeCommandLineAPI, Maybe<bool> in_silent, Maybe<int> in_contextId, Maybe<bool> in_returnByValue, Maybe<bool> in_generatePreview, Maybe<bool> in_userGesture, Maybe<bool> in_awaitPromise, std::unique_ptr<EvaluateCallback> callback) = 0;
+    class  AwaitPromiseCallback {
+    public:
+        virtual void sendSuccess(std::unique_ptr<protocol::Runtime::RemoteObject> result, Maybe<protocol::Runtime::ExceptionDetails> exceptionDetails) = 0;
+        virtual void sendFailure(const DispatchResponse&) = 0;
+        virtual void fallThrough() = 0;
+        virtual ~AwaitPromiseCallback() { }
+    };
+    virtual void awaitPromise(const String& in_promiseObjectId, Maybe<bool> in_returnByValue, Maybe<bool> in_generatePreview, std::unique_ptr<AwaitPromiseCallback> callback) = 0;
+    class  CallFunctionOnCallback {
+    public:
+        virtual void sendSuccess(std::unique_ptr<protocol::Runtime::RemoteObject> result, Maybe<protocol::Runtime::ExceptionDetails> exceptionDetails) = 0;
+        virtual void sendFailure(const DispatchResponse&) = 0;
+        virtual void fallThrough() = 0;
+        virtual ~CallFunctionOnCallback() { }
+    };
+    virtual void callFunctionOn(const String& in_objectId, const String& in_functionDeclaration, Maybe<protocol::Array<protocol::Runtime::CallArgument>> in_arguments, Maybe<bool> in_silent, Maybe<bool> in_returnByValue, Maybe<bool> in_generatePreview, Maybe<bool> in_userGesture, Maybe<bool> in_awaitPromise, std::unique_ptr<CallFunctionOnCallback> callback) = 0;
+    virtual DispatchResponse getProperties(const String& in_objectId, Maybe<bool> in_ownProperties, Maybe<bool> in_accessorPropertiesOnly, Maybe<bool> in_generatePreview, std::unique_ptr<protocol::Array<protocol::Runtime::PropertyDescriptor>>* out_result, Maybe<protocol::Array<protocol::Runtime::InternalPropertyDescriptor>>* out_internalProperties, Maybe<protocol::Runtime::ExceptionDetails>* out_exceptionDetails) = 0;
+    virtual DispatchResponse releaseObject(const String& in_objectId) = 0;
+    virtual DispatchResponse releaseObjectGroup(const String& in_objectGroup) = 0;
+    virtual DispatchResponse runIfWaitingForDebugger() = 0;
+    virtual DispatchResponse enable() = 0;
+    virtual DispatchResponse disable() = 0;
+    virtual DispatchResponse discardConsoleEntries() = 0;
+    virtual DispatchResponse setCustomObjectFormatterEnabled(bool in_enabled) = 0;
+    virtual DispatchResponse compileScript(const String& in_expression, const String& in_sourceURL, bool in_persistScript, Maybe<int> in_executionContextId, Maybe<String>* out_scriptId, Maybe<protocol::Runtime::ExceptionDetails>* out_exceptionDetails) = 0;
+    class  RunScriptCallback {
+    public:
+        virtual void sendSuccess(std::unique_ptr<protocol::Runtime::RemoteObject> result, Maybe<protocol::Runtime::ExceptionDetails> exceptionDetails) = 0;
+        virtual void sendFailure(const DispatchResponse&) = 0;
+        virtual void fallThrough() = 0;
+        virtual ~RunScriptCallback() { }
+    };
+    virtual void runScript(const String& in_scriptId, Maybe<int> in_executionContextId, Maybe<String> in_objectGroup, Maybe<bool> in_silent, Maybe<bool> in_includeCommandLineAPI, Maybe<bool> in_returnByValue, Maybe<bool> in_generatePreview, Maybe<bool> in_awaitPromise, std::unique_ptr<RunScriptCallback> callback) = 0;
+
+};
+
+// ------------- Frontend interface.
+
+class  Frontend {
+public:
+    explicit Frontend(FrontendChannel* frontendChannel) : m_frontendChannel(frontendChannel) { }
+    void executionContextCreated(std::unique_ptr<protocol::Runtime::ExecutionContextDescription> context);
+    void executionContextDestroyed(int executionContextId);
+    void executionContextsCleared();
+    void exceptionThrown(double timestamp, std::unique_ptr<protocol::Runtime::ExceptionDetails> exceptionDetails);
+    void exceptionRevoked(const String& reason, int exceptionId);
+    void consoleAPICalled(const String& type, std::unique_ptr<protocol::Array<protocol::Runtime::RemoteObject>> args, int executionContextId, double timestamp, Maybe<protocol::Runtime::StackTrace> stackTrace = Maybe<protocol::Runtime::StackTrace>());
+    void inspectRequested(std::unique_ptr<protocol::Runtime::RemoteObject> object, std::unique_ptr<protocol::DictionaryValue> hints);
+
+    void flush();
+    void sendRawNotification(const String&);
+private:
+    FrontendChannel* m_frontendChannel;
+};
+
+// ------------- Dispatcher.
+
+class  Dispatcher {
+public:
+    static void wire(UberDispatcher*, Backend*);
+
+private:
+    Dispatcher() { }
+};
+
+// ------------- Metainfo.
+
+class  Metainfo {
+public:
+    using BackendClass = Backend;
+    using FrontendClass = Frontend;
+    using DispatcherClass = Dispatcher;
+    static const char domainName[];
+    static const char commandPrefix[];
+    static const char version[];
+};
+
+} // namespace Runtime
+} // namespace JsDebug
+} // namespace protocol
+
+#endif // !defined(JsDebug_protocol_Runtime_h)

--- a/lib/Debug.Protocol/Generated/protocol/Schema.cpp
+++ b/lib/Debug.Protocol/Generated/protocol/Schema.cpp
@@ -1,0 +1,157 @@
+// This file is generated
+
+// Copyright (c) 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "protocol/Schema.h"
+
+#include "protocol/Protocol.h"
+
+namespace JsDebug {
+namespace protocol {
+namespace Schema {
+
+// ------------- Enum values from types.
+
+const char Metainfo::domainName[] = "Schema";
+const char Metainfo::commandPrefix[] = "Schema.";
+const char Metainfo::version[] = "1.2";
+
+std::unique_ptr<Domain> Domain::fromValue(protocol::Value* value, ErrorSupport* errors)
+{
+    if (!value || value->type() != protocol::Value::TypeObject) {
+        errors->addError("object expected");
+        return nullptr;
+    }
+
+    std::unique_ptr<Domain> result(new Domain());
+    protocol::DictionaryValue* object = DictionaryValue::cast(value);
+    errors->push();
+    protocol::Value* nameValue = object->get("name");
+    errors->setName("name");
+    result->m_name = ValueConversions<String>::fromValue(nameValue, errors);
+    protocol::Value* versionValue = object->get("version");
+    errors->setName("version");
+    result->m_version = ValueConversions<String>::fromValue(versionValue, errors);
+    errors->pop();
+    if (errors->hasErrors())
+        return nullptr;
+    return result;
+}
+
+std::unique_ptr<protocol::DictionaryValue> Domain::toValue() const
+{
+    std::unique_ptr<protocol::DictionaryValue> result = DictionaryValue::create();
+    result->setValue("name", ValueConversions<String>::toValue(m_name));
+    result->setValue("version", ValueConversions<String>::toValue(m_version));
+    return result;
+}
+
+std::unique_ptr<Domain> Domain::clone() const
+{
+    ErrorSupport errors;
+    return fromValue(toValue().get(), &errors);
+}
+
+std::unique_ptr<StringBuffer> Domain::toJSONString() const
+{
+    String json = toValue()->serialize();
+    return StringBufferImpl::adopt(json);
+}
+
+// static
+std::unique_ptr<API::Domain> API::Domain::fromJSONString(const StringView& json)
+{
+    ErrorSupport errors;
+    std::unique_ptr<Value> value = StringUtil::parseJSON(json);
+    if (!value)
+        return nullptr;
+    return protocol::Schema::Domain::fromValue(value.get(), &errors);
+}
+
+// ------------- Enum values from params.
+
+
+// ------------- Frontend notifications.
+
+void Frontend::flush()
+{
+    m_frontendChannel->flushProtocolNotifications();
+}
+
+void Frontend::sendRawNotification(const String& notification)
+{
+    m_frontendChannel->sendProtocolNotification(InternalRawNotification::create(notification));
+}
+
+// --------------------- Dispatcher.
+
+class DispatcherImpl : public protocol::DispatcherBase {
+public:
+    DispatcherImpl(FrontendChannel* frontendChannel, Backend* backend, bool fallThroughForNotFound)
+        : DispatcherBase(frontendChannel)
+        , m_backend(backend)
+        , m_fallThroughForNotFound(fallThroughForNotFound) {
+        m_dispatchMap["Schema.getDomains"] = &DispatcherImpl::getDomains;
+    }
+    ~DispatcherImpl() override { }
+    DispatchResponse::Status dispatch(int callId, const String& method, std::unique_ptr<protocol::DictionaryValue> messageObject) override;
+    HashMap<String, String>& redirects() { return m_redirects; }
+
+protected:
+    using CallHandler = DispatchResponse::Status (DispatcherImpl::*)(int callId, std::unique_ptr<DictionaryValue> messageObject, ErrorSupport* errors);
+    using DispatchMap = protocol::HashMap<String, CallHandler>;
+    DispatchMap m_dispatchMap;
+    HashMap<String, String> m_redirects;
+
+    DispatchResponse::Status getDomains(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport*);
+
+    Backend* m_backend;
+    bool m_fallThroughForNotFound;
+};
+
+DispatchResponse::Status DispatcherImpl::dispatch(int callId, const String& method, std::unique_ptr<protocol::DictionaryValue> messageObject)
+{
+    protocol::HashMap<String, CallHandler>::iterator it = m_dispatchMap.find(method);
+    if (it == m_dispatchMap.end()) {
+        if (m_fallThroughForNotFound)
+            return DispatchResponse::kFallThrough;
+        reportProtocolError(callId, DispatchResponse::kMethodNotFound, "'" + method + "' wasn't found", nullptr);
+        return DispatchResponse::kError;
+    }
+
+    protocol::ErrorSupport errors;
+    return (this->*(it->second))(callId, std::move(messageObject), &errors);
+}
+
+
+DispatchResponse::Status DispatcherImpl::getDomains(int callId, std::unique_ptr<DictionaryValue> requestMessageObject, ErrorSupport* errors)
+{
+    // Declare output parameters.
+    std::unique_ptr<protocol::Array<protocol::Schema::Domain>> out_domains;
+
+    std::unique_ptr<DispatcherBase::WeakPtr> weak = weakPtr();
+    DispatchResponse response = m_backend->getDomains(&out_domains);
+    if (response.status() == DispatchResponse::kFallThrough)
+        return response.status();
+    std::unique_ptr<protocol::DictionaryValue> result = DictionaryValue::create();
+    if (response.status() == DispatchResponse::kSuccess) {
+        result->setValue("domains", ValueConversions<protocol::Array<protocol::Schema::Domain>>::toValue(out_domains.get()));
+    }
+    if (weak->get())
+        weak->get()->sendResponse(callId, response, std::move(result));
+    return response.status();
+}
+
+// static
+void Dispatcher::wire(UberDispatcher* uber, Backend* backend)
+{
+    std::unique_ptr<DispatcherImpl> dispatcher(new DispatcherImpl(uber->channel(), backend, uber->fallThroughForNotFound()));
+    uber->setupRedirects(dispatcher->redirects());
+    uber->registerBackend("Schema", std::move(dispatcher));
+}
+
+} // Schema
+} // namespace JsDebug
+} // namespace protocol

--- a/lib/Debug.Protocol/Generated/protocol/Schema.h
+++ b/lib/Debug.Protocol/Generated/protocol/Schema.h
@@ -1,0 +1,151 @@
+// This file is generated
+
+// Copyright (c) 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef JsDebug_protocol_Schema_h
+#define JsDebug_protocol_Schema_h
+
+#include "protocol/Protocol.h"
+// For each imported domain we generate a ValueConversions struct instead of a full domain definition
+// and include Domain::API version from there.
+#include "include/Schema.h"
+
+namespace JsDebug {
+namespace protocol {
+namespace Schema {
+
+// ------------- Forward and enum declarations.
+class Domain;
+
+// ------------- Type and builder declarations.
+
+class  Domain : public Serializable, public API::Domain{
+    PROTOCOL_DISALLOW_COPY(Domain);
+public:
+    static std::unique_ptr<Domain> fromValue(protocol::Value* value, ErrorSupport* errors);
+
+    ~Domain() override { }
+
+    String getName() { return m_name; }
+    void setName(const String& value) { m_name = value; }
+
+    String getVersion() { return m_version; }
+    void setVersion(const String& value) { m_version = value; }
+
+    std::unique_ptr<protocol::DictionaryValue> toValue() const;
+    String serialize() override { return toValue()->serialize(); }
+    std::unique_ptr<Domain> clone() const;
+    std::unique_ptr<StringBuffer> toJSONString() const override;
+
+    template<int STATE>
+    class DomainBuilder {
+    public:
+        enum {
+            NoFieldsSet = 0,
+            NameSet = 1 << 1,
+            VersionSet = 1 << 2,
+            AllFieldsSet = (NameSet | VersionSet | 0)};
+
+
+        DomainBuilder<STATE | NameSet>& setName(const String& value)
+        {
+            static_assert(!(STATE & NameSet), "property name should not be set yet");
+            m_result->setName(value);
+            return castState<NameSet>();
+        }
+
+        DomainBuilder<STATE | VersionSet>& setVersion(const String& value)
+        {
+            static_assert(!(STATE & VersionSet), "property version should not be set yet");
+            m_result->setVersion(value);
+            return castState<VersionSet>();
+        }
+
+        std::unique_ptr<Domain> build()
+        {
+            static_assert(STATE == AllFieldsSet, "state should be AllFieldsSet");
+            return std::move(m_result);
+        }
+
+    private:
+        friend class Domain;
+        DomainBuilder() : m_result(new Domain()) { }
+
+        template<int STEP> DomainBuilder<STATE | STEP>& castState()
+        {
+            return *reinterpret_cast<DomainBuilder<STATE | STEP>*>(this);
+        }
+
+        std::unique_ptr<protocol::Schema::Domain> m_result;
+    };
+
+    static DomainBuilder<0> create()
+    {
+        return DomainBuilder<0>();
+    }
+
+private:
+    Domain()
+    {
+    }
+
+    String m_name;
+    String m_version;
+};
+
+
+// ------------- Backend interface.
+
+class  Backend {
+public:
+    virtual ~Backend() { }
+
+    virtual DispatchResponse getDomains(std::unique_ptr<protocol::Array<protocol::Schema::Domain>>* out_domains) = 0;
+
+    virtual DispatchResponse disable()
+    {
+        return DispatchResponse::OK();
+    }
+};
+
+// ------------- Frontend interface.
+
+class  Frontend {
+public:
+    explicit Frontend(FrontendChannel* frontendChannel) : m_frontendChannel(frontendChannel) { }
+
+    void flush();
+    void sendRawNotification(const String&);
+private:
+    FrontendChannel* m_frontendChannel;
+};
+
+// ------------- Dispatcher.
+
+class  Dispatcher {
+public:
+    static void wire(UberDispatcher*, Backend*);
+
+private:
+    Dispatcher() { }
+};
+
+// ------------- Metainfo.
+
+class  Metainfo {
+public:
+    using BackendClass = Backend;
+    using FrontendClass = Frontend;
+    using DispatcherClass = Dispatcher;
+    static const char domainName[];
+    static const char commandPrefix[];
+    static const char version[];
+};
+
+} // namespace Schema
+} // namespace JsDebug
+} // namespace protocol
+
+#endif // !defined(JsDebug_protocol_Schema_h)

--- a/lib/Debug.ProtocolHandler/Debug.ProtocolHandler.vcxproj
+++ b/lib/Debug.ProtocolHandler/Debug.ProtocolHandler.vcxproj
@@ -90,7 +90,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>..\Debug.Protocol\;..\Debug.Protocol\$(IntermediateOutputPath);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\Debug.Protocol\;..\Debug.Protocol\Generated;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -105,7 +105,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>..\Debug.Protocol\;..\Debug.Protocol\$(IntermediateOutputPath);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\Debug.Protocol\;..\Debug.Protocol\Generated;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -122,7 +122,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>..\Debug.Protocol\;..\Debug.Protocol\$(IntermediateOutputPath);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\Debug.Protocol\;..\Debug.Protocol\Generated;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -141,7 +141,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>..\Debug.Protocol\;..\Debug.Protocol\$(IntermediateOutputPath);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\Debug.Protocol\;..\Debug.Protocol\Generated;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>


### PR DESCRIPTION
I went ahead and did this work for issue https://github.com/kfarnung/ChakraCore-Debugger/issues/55.

Instead of running GenerateProtocol.py as a pre-build step, GenerateProtocol.bat allows it to be run manually when needed.  The generated files are put in "generated" folder, and the projects updated to include that directory. The "generated" folder is deleted before running GenerateProtocol.py so that obsolete files are deleted.

I added __jinja*.cache to .gitignore. I don't think they are necessary, especially since the entire folder is deleted before generation. They could also be deleted after running GenerateProtocol.py but there's a delay before they are written so it couldn't be done easily in the batch file. 
